### PR TITLE
共通エラー表示処理

### DIFF
--- a/atom/userAtom.ts
+++ b/atom/userAtom.ts
@@ -1,5 +1,6 @@
 import { atom } from "recoil";
 import { AuthState } from "../hook/useAuthState";
+import { ErrorState } from "../interfaces";
 
 const DEFAULT_AUTH_STATE: AuthState = {
   isLogined: false,
@@ -10,4 +11,9 @@ const DEFAULT_AUTH_STATE: AuthState = {
 export const authState = atom<AuthState>({
   key: "user/auth",
   default: DEFAULT_AUTH_STATE,
+});
+
+export const errorState = atom<ErrorState[]>({
+  key: "sys/error",
+  default: [],
 });

--- a/components/Error/ErrorView.tsx
+++ b/components/Error/ErrorView.tsx
@@ -1,0 +1,24 @@
+import { Alert, AlertTitle } from "@mui/material";
+import { useErrorState } from "../../hook/useErrorState";
+
+const ErrorView = () => {
+  const { errors } = useErrorState();
+  return (
+    <>
+      {errors.length > 0 ? (
+        <Alert severity="error">
+          <AlertTitle>Error</AlertTitle>
+          <ul>
+            {errors.map((e) => (
+              <li>{e.message}</li>
+            ))}
+          </ul>
+        </Alert>
+      ) : (
+        <></>
+      )}
+    </>
+  );
+};
+
+export default ErrorView;

--- a/hook/event/useEventDetail.ts
+++ b/hook/event/useEventDetail.ts
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { DigicreEvent, DigicreEventDetail } from "../../interfaces/event";
 import { axios } from "../../utils/axios";
 import { useAuthState } from "../useAuthState";
+import { useErrorState } from "../useErrorState";
 
 type UseEventDetail = (id: string) => {
   isLoading: boolean;
@@ -14,6 +15,7 @@ const useEventDetail: UseEventDetail = (id) => {
   const [eventDetail, setEventDetail] = useState<DigicreEventDetail>();
   const [eventNotFound, setEventNotFound] = useState(false);
   const { authState } = useAuthState();
+  const { setNewError, removeError } = useErrorState();
   useEffect(() => {
     const getFunc = async () => {
       if (!authState.isLogined) return;
@@ -26,35 +28,53 @@ const useEventDetail: UseEventDetail = (id) => {
 
         const ed: DigicreEventDetail = res.data;
         setEventDetail(ed);
+        removeError("eventdetail-get-fail");
       } catch (err: any) {
         const msg: string = err.message;
         if (msg.indexOf("404") !== -1) setEventNotFound(true);
+        setNewError({ name: "eventdetail-get-fail", message: "イベント詳細の取得に失敗しました" });
       }
     };
     getFunc();
   }, [authState]);
 
   const reservation = async (frameId: string, commentText: string, urlText: string) => {
-    const res = await axios.post(
-      `/event/${id}/${frameId}`,
-      {
-        comment: commentText,
-        url: urlText,
-      },
-      {
-        headers: {
-          Authorization: "bearer " + authState.token,
+    try {
+      const res = await axios.post(
+        `/event/${id}/${frameId}`,
+        {
+          comment: commentText,
+          url: urlText,
         },
-      },
-    );
+        {
+          headers: {
+            Authorization: "bearer " + authState.token,
+          },
+        },
+      );
+      removeError("eventdetailreservation-post-fail");
+    } catch (err) {
+      setNewError({
+        name: "eventdetailreservation-post-fail",
+        message: "イベント枠予約に失敗しました",
+      });
+    }
     return true;
   };
   const cancelReservation = async (frameId: string) => {
-    const res = await axios.delete(`/event/${id}/${frameId}`, {
-      headers: {
-        Authorization: "bearer " + authState.token,
-      },
-    });
+    try {
+      const res = await axios.delete(`/event/${id}/${frameId}`, {
+        headers: {
+          Authorization: "bearer " + authState.token,
+        },
+      });
+      removeError("eventdetailreservation-delete-fail");
+    } catch (err) {
+      setNewError({
+        name: "eventdetailreservation-delete-fail",
+        message: "イベント枠予約キャンセルに失敗しました",
+      });
+    }
     return true;
   };
 

--- a/hook/event/useEventList.ts
+++ b/hook/event/useEventList.ts
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { DigicreEvent, EventListAPIData } from "../../interfaces/event";
 import { axios } from "../../utils/axios";
 import { useAuthState } from "../useAuthState";
+import { useErrorState } from "../useErrorState";
 
 type UseEventList = () => {
   isLoading: boolean;
@@ -11,6 +12,7 @@ type UseEventList = () => {
 export const useEventList: UseEventList = () => {
   const [events, setEvents] = useState<DigicreEvent[]>();
   const { authState } = useAuthState();
+  const { setNewError, removeError } = useErrorState();
   useEffect(() => {
     if (authState.isLoading || !authState.isLogined) return;
     const getData = async () => {
@@ -22,8 +24,10 @@ export const useEventList: UseEventList = () => {
         });
         const eventRes: EventListAPIData = res.data;
         setEvents(eventRes.events);
+        removeError("eventlist-get-fail");
       } catch (err) {
         console.log(err);
+        setNewError({ name: "eventlist-get-fail", message: "イベント一覧の取得に失敗しました" });
       }
     };
     getData();

--- a/hook/useAuthState.ts
+++ b/hook/useAuthState.ts
@@ -21,7 +21,7 @@ type UseAuthState = () => {
 
 export const useAuthState: UseAuthState = () => {
   const [auth, setAuth] = useRecoilState(authState);
-  const { setNewError } = useErrorState();
+  const { setNewError, removeError } = useErrorState();
   const getUserInfo = (token: string) => {
     axios
       .get("/user/my", {
@@ -37,10 +37,11 @@ export const useAuthState: UseAuthState = () => {
           user: convertUserFromUserProfile(userProfileAPIDataResponse),
           token: token,
         });
+        removeError("autologin-fail");
       })
       .catch((err) => {
         setAuth({ isLogined: false, isLoading: false, user: undefined, token: undefined });
-        setNewError({ name: "login-fail", message: "ログインしてください" });
+        setNewError({ name: "autologin-fail", message: "ログインしてください" });
       });
   };
   // ローカルストレージを削除する関数

--- a/hook/useAuthState.ts
+++ b/hook/useAuthState.ts
@@ -4,6 +4,7 @@ import { authState } from "../atom/userAtom";
 import { useEffect } from "react";
 import { axios } from "../utils/axios";
 import { UserProfileAPIDataResponse, convertUserFromUserProfile } from "../interfaces/api";
+import { useErrorState } from "./useErrorState";
 
 export type AuthState = {
   isLogined: boolean;
@@ -20,6 +21,7 @@ type UseAuthState = () => {
 
 export const useAuthState: UseAuthState = () => {
   const [auth, setAuth] = useRecoilState(authState);
+  const { setNewError } = useErrorState();
   const getUserInfo = (token: string) => {
     axios
       .get("/user/my", {
@@ -38,6 +40,7 @@ export const useAuthState: UseAuthState = () => {
       })
       .catch((err) => {
         setAuth({ isLogined: false, isLoading: false, user: undefined, token: undefined });
+        setNewError({ name: "login-fail", message: "ログインしてください" });
       });
   };
   // ローカルストレージを削除する関数

--- a/hook/useErrorState.ts
+++ b/hook/useErrorState.ts
@@ -5,6 +5,7 @@ type UseErrorState = () => {
   errors: ErrorState[];
   setNewError: (error: ErrorState) => void;
   resetError: () => void;
+  removeError: (errorName: string) => void;
 };
 
 export const useErrorState: UseErrorState = () => {
@@ -26,9 +27,14 @@ export const useErrorState: UseErrorState = () => {
     setErrors([]);
   };
 
+  const removeError = (errorName: string) => {
+    setErrors(errors.filter((e) => e.name !== errorName));
+  };
+
   return {
     errors: errors,
     setNewError: setNewError,
     resetError: resetError,
+    removeError: removeError,
   };
 };

--- a/hook/useErrorState.ts
+++ b/hook/useErrorState.ts
@@ -4,17 +4,30 @@ import { ErrorState } from "../interfaces";
 type UseErrorState = () => {
   errors: ErrorState[];
   setNewError: (error: ErrorState) => void;
+  resetError: () => void;
 };
 
 export const useErrorState: UseErrorState = () => {
   const [errors, setErrors] = useRecoilState(errorState);
 
   const setNewError = (error: ErrorState) => {
-    setErrors([...errors, error]);
+    if (errors.find((e) => e.name === error.name) === undefined) {
+      //新規エラー
+      setErrors([...errors, error]);
+    } else {
+      //既存エラー
+      errors.find((e) => e.name === error.name).count++;
+      setErrors(errors);
+    }
+  };
+
+  const resetError = () => {
+    setErrors([]);
   };
 
   return {
     errors: errors,
     setNewError: setNewError,
+    resetError: resetError,
   };
 };

--- a/hook/useErrorState.ts
+++ b/hook/useErrorState.ts
@@ -1,0 +1,20 @@
+import { useRecoilState } from "recoil";
+import { errorState } from "../atom/userAtom";
+import { ErrorState } from "../interfaces";
+type UseErrorState = () => {
+  errors: ErrorState[];
+  setNewError: (error: ErrorState) => void;
+};
+
+export const useErrorState: UseErrorState = () => {
+  const [errors, setErrors] = useRecoilState(errorState);
+
+  const setNewError = (error: ErrorState) => {
+    setErrors([...errors, error]);
+  };
+
+  return {
+    errors: errors,
+    setNewError: setNewError,
+  };
+};

--- a/hook/useErrorState.ts
+++ b/hook/useErrorState.ts
@@ -13,6 +13,7 @@ export const useErrorState: UseErrorState = () => {
   const setNewError = (error: ErrorState) => {
     if (errors.find((e) => e.name === error.name) === undefined) {
       //新規エラー
+      error.count = 0;
       setErrors([...errors, error]);
     } else {
       //既存エラー

--- a/hook/usePaymentState.ts
+++ b/hook/usePaymentState.ts
@@ -2,6 +2,7 @@ import { axios } from "../utils/axios";
 import { Dispatch, SetStateAction, useEffect, useState } from "react";
 import { GetPaymentAPIData, GetPaymentHistoryAPIData, PaymentAPIData } from "../interfaces/api";
 import { useAuthState } from "./useAuthState";
+import { useErrorState } from "./useErrorState";
 
 type UsePaymentState = () => {
   isLoading: boolean;
@@ -15,6 +16,7 @@ export const usePaymentState: UsePaymentState = () => {
   const [latestPayment, setLatestPayment] = useState<PaymentAPIData>();
   const [paymentHistory, setPaymentHistory] = useState<PaymentAPIData[]>();
   const { authState } = useAuthState();
+  const { setNewError } = useErrorState();
   useEffect(() => {
     if (authState.isLoading || !authState.isLogined) return;
     const getData = async () => {
@@ -24,7 +26,10 @@ export const usePaymentState: UsePaymentState = () => {
         },
       });
       const history: GetPaymentHistoryAPIData = historyRes.data;
-      if (historyRes.status !== 200) return;
+      if (historyRes.status !== 200) {
+        setNewError({ name: "payment-get", message: "部費支払い情報の取得に失敗しました" });
+        return;
+      }
       setPaymentHistory(history.payments);
       try {
         const res = await axios.get("user/my/payment", {
@@ -51,6 +56,7 @@ export const usePaymentState: UsePaymentState = () => {
       },
     });
     if (res.status === 200) return true;
+    setNewError({ name: "payment-update", message: "部費支払い情報の更新に失敗しました" });
     return false;
   };
   return {

--- a/interfaces/index.ts
+++ b/interfaces/index.ts
@@ -21,5 +21,7 @@ export type User = {
 };
 
 export type ErrorState = {
+  name: string;
+  count: number;
   message: string;
 };

--- a/interfaces/index.ts
+++ b/interfaces/index.ts
@@ -22,6 +22,6 @@ export type User = {
 
 export type ErrorState = {
   name: string;
-  count: number;
+  count?: number;
   message: string;
 };

--- a/interfaces/index.ts
+++ b/interfaces/index.ts
@@ -19,3 +19,7 @@ export type User = {
   self_introduction?: string;
   shortSelfIntroduction?: string;
 };
+
+export type ErrorState = {
+  message: string;
+};

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,11 +2,13 @@ import { RecoilRoot } from "recoil";
 import NavBar from "../components/Home/NavBar";
 import "../style/common.css";
 import "highlightjs/styles/vs2015.css";
+import ErrorView from "../components/Error/ErrorView";
 
 const App = ({ Component, pageProps }) => {
   return (
     <RecoilRoot>
       <NavBar />
+      <ErrorView />
       <Component {...pageProps} />
     </RecoilRoot>
   );

--- a/pages/logined.tsx
+++ b/pages/logined.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/router";
 import { setCookie } from "nookies";
 import { GetServerSideProps } from "next";
 import { useAuthState } from "../hook/useAuthState";
+import { useErrorState } from "../hook/useErrorState";
 type Props = {
   isLoginFailed: boolean;
   token: string;
@@ -13,9 +14,15 @@ type Props = {
 const LoginResultPage = ({ isLoginFailed, token }: Props) => {
   const router = useRouter();
   const { authState, onLogin } = useAuthState();
+  const { setNewError, resetError, removeError } = useErrorState();
   useEffect(() => {
+    resetError();
     onLogin(token);
-    if (!isLoginFailed) router.push("/");
+    if (!isLoginFailed) {
+      removeError("login-fail");
+      router.push("/");
+    }
+    setNewError({ name: "login-fail", message: "ログインに失敗しました" });
   }, []);
   return (
     <>


### PR DESCRIPTION
エラー表示の共通処理を作成

エラーなどが発生する可能性があるコンポーネントやHookにて`const {setNewError, removeError} = useErrorState()`を記載し、使うことが出来る。

見た目
![image](https://user-images.githubusercontent.com/30793866/176999574-6744fdbd-434b-4d8b-a75e-22a52de537bc.png)
