### PR TITLE
新規登録後にjoinedページに遷移しない問題を修正

### DIFF
--- a/components/Profile/ProfileRegister.tsx
+++ b/components/Profile/ProfileRegister.tsx
@@ -25,12 +25,6 @@ const ProfileRegister = ({ registerMode }: Props) => {
     if (!authState.isLogined) return;
     setUser(authState.user);
   }, [authState]);
-  useEffect(() => {
-    const value = sessionStorage.getItem("register");
-    if (value === null) return;
-    sessionStorage.removeItem("register");
-    router.push("/user/joined");
-  }, []);
   const onChangeUserName: ChangeEventHandler<HTMLInputElement> = (e) => {
     setUser((state) => ({ ...state, username: e.target.value }));
   };

--- a/pages/user/profile.tsx
+++ b/pages/user/profile.tsx
@@ -1,6 +1,7 @@
 import { Container } from "@mui/material";
 import { GetServerSideProps } from "next";
 import { useRouter } from "next/router";
+import { useEffect } from "react";
 import ProfileEditor from "../../components/Profile/ProfileEditor";
 import ProfileRegister from "../../components/Profile/ProfileRegister";
 import { useAuthState } from "../../hook/useAuthState";
@@ -11,7 +12,12 @@ type Props = {
 const ProfilePage = ({ registerMode }: Props) => {
   const router = useRouter();
   const { authState } = useAuthState();
-
+  useEffect(() => {
+    const value = sessionStorage.getItem("register");
+    if (value === null) return;
+    sessionStorage.removeItem("register");
+    router.push("/user/joined");
+  }, []);
   return (
     <>
       {authState.isLoading || !authState.isLogined ? (


### PR DESCRIPTION
## 概要

- [x] joinedに遷移する処理をregister=trueが無くても動くように移動

## スクリーンショット（変更の場合は変更前と変更後が分かるように）

## 破壊的変更があるか(あれば内容を記載)

- [ ] YES
- [x] NO

## チェック項目

- [x] ビルドが通る
- [x] 作成した機能が想定通りに動作する
- [ ] スマートフォンサイズで表示確認を行った
- [x] warning が増えていない
- [ ] 複雑なコードにはコメントを記載してある
