### PR TITLE
デフォルトのフォントとしてNotoSansJPを導入

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -12,6 +12,10 @@ const App = ({ Component, pageProps }) => {
         <link rel="apple-touch-icon" sizes="180x180" href="/favicon.ico" />
         <link rel="icon" type="image/png" sizes="32x32" href="/favicon.ico" />
         <link rel="icon" type="image/png" sizes="16x16" href="/favicon.ico" />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@100;300;400;500;600;700&display=swap"
+          rel="stylesheet"
+        />
       </Head>
       <NavBar />
       <ErrorView />

--- a/style/common.css
+++ b/style/common.css
@@ -2,6 +2,7 @@
   box-sizing: border-box;
   margin: 0;
   padding: 0;
+  font-family: "Noto Sans JP";
 }
 .index_calender {
   position: relative;


### PR DESCRIPTION
## 概要

- [x] GoogleFontsにてNotoSansJPを導入、デフォルトのフォントに指定

## スクリーンショット（変更の場合は変更前と変更後が分かるように）
### Before
![image](https://user-images.githubusercontent.com/30793866/183311210-cfccf976-0be8-4ae4-b3a0-669d59accba9.png)


### After
![image](https://user-images.githubusercontent.com/30793866/183311199-645ec0a9-04c5-4dbd-a992-58675a44afb2.png)

## 破壊的変更があるか(あれば内容を記載)

- [ ] YES
- [x] NO

## チェック項目

- [x] ビルドが通る
- [x] 作成した機能が想定通りに動作する
- [x] スマートフォンサイズで表示確認を行った
- [x] warning が増えていない
- [ ] 複雑なコードにはコメントを記載してある
