### PR TITLE
ダークモード時にリンクが見にくい問題を修正

### DIFF
--- a/style/common.css
+++ b/style/common.css
@@ -83,3 +83,6 @@ blockquote cite {
 .breadcrumbs-link:hover {
   text-decoration: underline;
 }
+a {
+  color: rgb(117, 201, 230);
+}


### PR DESCRIPTION
## 概要
Fix #52 
- [x] aタグに対して色を指定

## スクリーンショット（変更の場合は変更前と変更後が分かるように）

![image](https://user-images.githubusercontent.com/30793866/188202427-9bdb623f-ecee-4edb-8667-55ec8f935f3a.png)
![image](https://user-images.githubusercontent.com/30793866/188202489-6da967c5-e74f-4709-bd93-df8eb5dc95b8.png)


## 破壊的変更があるか(あれば内容を記載)

- [ ] YES
- [x] NO

## チェック項目

- [x] ビルドが通る
- [x] 作成した機能が想定通りに動作する
- [ ] スマートフォンサイズで表示確認を行った
- [ ] warning が増えていない
- [ ] 複雑なコードにはコメントを記載してある
