### PR TITLE
Mattermostへの導線を改善

### DIFF
--- a/components/Common/FloatingWindow.tsx
+++ b/components/Common/FloatingWindow.tsx
@@ -1,0 +1,26 @@
+import { Alert, Box } from "@mui/material";
+import Link from "next/link";
+
+type Props = {
+  to: string;
+  text: string;
+};
+const style = {};
+
+const FloatingWindow = ({ to, text }: Props) => {
+  return (
+    <Box
+      style={{
+        position: "fixed",
+        left: 10,
+        top: 10,
+      }}
+    >
+      <Alert severity="info">
+        <Link href={to}>{text}</Link>
+      </Alert>
+    </Box>
+  );
+};
+
+export default FloatingWindow;

--- a/components/Mattermost/Agreement.tsx
+++ b/components/Mattermost/Agreement.tsx
@@ -15,6 +15,7 @@ import PageHead from "../../components/Common/PageHead";
 import Breadcrumbs from "../../components/Common/Breadcrumb";
 import { MattermostDisplayPage } from "../../interfaces/mattermost";
 import { User } from "../../interfaces";
+import { useRouter } from "next/router";
 
 type Props = {
   displayPageSetter: (page: MattermostDisplayPage) => void;
@@ -24,6 +25,7 @@ export const MattermostAgreement = ({ displayPageSetter }: Props) => {
   const [agree, setAgree] = useState(false);
   const { authState } = useAuthState();
   const userProfile = authState.user;
+  const router = useRouter();
   const checkProfile = (userProfile: User): string | boolean => {
     if (userProfile.iconUrl.length === 0) {
       return "アイコンが設定されていません。";
@@ -152,9 +154,11 @@ export const MattermostAgreement = ({ displayPageSetter }: Props) => {
                 profileWarning !== true &&
                 confirm(profileWarning + "プロフィール編集画面に移動しますか？")
               ) {
-                window.open("/user/profile", "_blank");
+                //window.open("/user/profile", "_blank");
+                router.push(`/user/profile?backto=/mattermost`);
+              } else {
+                displayPageSetter("register");
               }
-              displayPageSetter("register");
             }}
           >
             Mattermost への登録を開始

--- a/components/Profile/ProfileEditor.tsx
+++ b/components/Profile/ProfileEditor.tsx
@@ -1,4 +1,5 @@
-import { Avatar, Button, Container, Grid, TextField } from "@mui/material";
+import { Alert, Avatar, Button, Container, Grid, TextField } from "@mui/material";
+import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import { useMyIntroduction } from "../../hook/profile/useIntroduction";
 import { useMyProfile } from "../../hook/profile/useProfile";
@@ -21,6 +22,7 @@ const ProfileEditor = () => {
     setEditUserIntro({ md: (" " + userIntro).slice(1) });
   }, [userIntro]);
   const [openFileModal, setOpenFileModal] = useState(false);
+  const router = useRouter();
   if (!userProfile || !editUserProfile || !editUserIntro) return <p>isLoading...</p>;
   const onAvatarImageSelected = (file: FileObject) => {
     setEditUserProfile({ ...editUserProfile, icon_url: file.url });
@@ -32,6 +34,11 @@ const ProfileEditor = () => {
         <h1>プロファイル編集</h1>
         <Grid sx={{ mb: 3 }}>
           <h2>公開情報（他の部員も見れる情報）</h2>
+          {userProfile.student_number === userProfile.username ? (
+            <Alert severity="warning">アイコンを設定しましょう!</Alert>
+          ) : (
+            <></>
+          )}
           {userProfile.icon_url === "" ? (
             <></>
           ) : (
@@ -53,6 +60,11 @@ const ProfileEditor = () => {
             onSelected={onAvatarImageSelected}
             onlyFileKind="image"
           />
+          {userProfile.student_number === userProfile.username ? (
+            <Alert severity="warning">ユーザー名を学番以外で設定しましょう!</Alert>
+          ) : (
+            <></>
+          )}
           <TextField
             label="ユーザー名"
             variant="outlined"
@@ -80,7 +92,9 @@ const ProfileEditor = () => {
             variant="contained"
             disabled={objectEquals(userProfile, editUserProfile)}
             onClick={() => {
-              updateProfile(editUserProfile);
+              updateProfile(editUserProfile).then(() => {
+                router.reload();
+              });
             }}
           >
             保存

--- a/pages/user/profile.tsx
+++ b/pages/user/profile.tsx
@@ -7,11 +7,13 @@ import PageHead from "../../components/Common/PageHead";
 import ProfileEditor from "../../components/Profile/ProfileEditor";
 import ProfileRegister from "../../components/Profile/ProfileRegister";
 import { useAuthState } from "../../hook/useAuthState";
+import FloatingWindow from "../../components/Common/FloatingWindow";
 
 type Props = {
   registerMode: boolean;
+  backtoUrl?: string;
 };
-const ProfilePage = ({ registerMode }: Props) => {
+const ProfilePage = ({ registerMode, backtoUrl }: Props) => {
   const router = useRouter();
   const { authState } = useAuthState();
   useEffect(() => {
@@ -29,6 +31,7 @@ const ProfilePage = ({ registerMode }: Props) => {
         <Container>
           <Breadcrumbs links={[{ text: "Home", href: "/" }, { text: "Profile" }]} />
           {registerMode ? <ProfileRegister registerMode={registerMode} /> : <ProfileEditor />}
+          <FloatingWindow to={backtoUrl} text={"Mattermostの登録に戻る"} />
         </Container>
       )}
     </>
@@ -36,10 +39,12 @@ const ProfilePage = ({ registerMode }: Props) => {
 };
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
-  const { register } = context.query;
+  const { register, backto } = context.query;
   let registerMode = false;
+  let backtoUrl: string | undefined = undefined;
   if (typeof register === "string") registerMode = register === "true";
-  const props: Props = { registerMode: registerMode };
+  if (typeof backto === "string") backtoUrl = backto;
+  const props: Props = { registerMode: registerMode, backtoUrl: backtoUrl };
   return {
     props: props,
   };


### PR DESCRIPTION
## 概要

- [x] Mattermostの登録画面に戻れるフローティングウインドウを実装
- [x] アイコンやユーザー名がデフォルトの場合、エディタで警告がでるように

## スクリーンショット（変更の場合は変更前と変更後が分かるように）
![image](https://user-images.githubusercontent.com/30793866/196157832-8c5aa6fb-3c52-45de-865c-780dac21aaff.png)

## 破壊的変更があるか(あれば内容を記載)

- [ ] YES
- [x] NO

## チェック項目

- [x] ビルドが通る
- [x] 作成した機能が想定通りに動作する
- [x] スマートフォンサイズで表示確認を行った
- [x] warning が増えていない
- [ ] 複雑なコードにはコメントを記載してある
