### PR TITLE
初回登録にてアイコン選択で直接アップローダーが起動するように変更

### DIFF
--- a/components/File/FileUploader.tsx
+++ b/components/File/FileUploader.tsx
@@ -1,7 +1,7 @@
 import { Box, Button, LinearProgress, Modal, Typography } from "@mui/material";
 import { ChangeEventHandler, useEffect, useState } from "react";
 import { useMyFiles } from "../../hook/file/useFile";
-import { FileObject } from "../../interfaces/file";
+import { FileKind, FileObject, getFileExtWithKind } from "../../interfaces/file";
 
 const style = {
   position: "absolute" as "absolute",
@@ -19,9 +19,19 @@ type FileUploaderProps = {
   open: boolean;
   onCancel: () => void;
   onUploaded: (fileObject: FileObject) => void;
+  onlyFileKind?: FileKind;
 };
-export const FileUploader = ({ open, onCancel, onUploaded }: FileUploaderProps) => {
+export const FileUploader = ({ open, onCancel, onUploaded, onlyFileKind }: FileUploaderProps) => {
   const [isOpen, setIsOpen] = useState(open);
+  const [availableExtStr, setAvailableExtStr] = useState<string>(undefined);
+  useEffect(() => {
+    if (!onlyFileKind) return;
+    let extStr = "";
+    getFileExtWithKind(onlyFileKind).forEach((ext, i, list) => {
+      extStr += "." + ext + (list.length - 1 === i ? "" : ",");
+    });
+    setAvailableExtStr(extStr);
+  }, [onlyFileKind]);
   useEffect(() => {
     setIsOpen(open);
     setErrorMsg(undefined);
@@ -64,7 +74,7 @@ export const FileUploader = ({ open, onCancel, onUploaded }: FileUploaderProps) 
     <Modal open={isOpen}>
       <Box sx={style}>
         <h2>ファイルアップロード</h2>
-        <input type="file" onChange={onChangeFileInput} />
+        <input type="file" onChange={onChangeFileInput} accept={availableExtStr} />
         {errorMsg ? <Typography color="error">{errorMsg}</Typography> : <></>}
         {uploading ? <LinearProgress color="success" sx={{ marginTop: 1 }} /> : <></>}
         <Button variant="contained" color="error" onClick={onClickCancel} sx={{ marginTop: 1 }}>

--- a/components/Profile/ProfileEditor.tsx
+++ b/components/Profile/ProfileEditor.tsx
@@ -8,8 +8,8 @@ import { FileObject } from "../../interfaces/file";
 import { User } from "../../interfaces/user";
 import { objectEquals } from "../../utils/common";
 import MarkdownEditor from "../Common/MarkdownEditor";
-import { FileBrowserModal } from "../File/FileBrowser";
 import PrivateProfileEditor from "./PrivateProfileEditor";
+import { FileUploader } from "../File/FileUploader";
 
 const ProfileEditor = () => {
   const [userProfile] = useMyProfile();
@@ -102,14 +102,17 @@ export const PublicProfileEditor = ({ onSave }: PublicProfileEditorProps) => {
       >
         アイコン設定
       </Button>
-      <FileBrowserModal
+      <FileUploader open={openFileModal} onCancel={() => {
+          setOpenFileModal(false);
+        }} onUploaded={onAvatarImageSelected} />
+      {/*<FileBrowserModal
         open={openFileModal}
         onCancel={() => {
           setOpenFileModal(false);
         }}
         onSelected={onAvatarImageSelected}
         onlyFileKind="image"
-      />
+      />*/}
       {userProfile.studentNumber === userProfile.username ? (
         <Alert severity="warning">ユーザー名を学番以外で設定しましょう!</Alert>
       ) : (

--- a/components/Profile/ProfileEditor.tsx
+++ b/components/Profile/ProfileEditor.tsx
@@ -102,9 +102,14 @@ export const PublicProfileEditor = ({ onSave }: PublicProfileEditorProps) => {
       >
         アイコン設定
       </Button>
-      <FileUploader open={openFileModal} onCancel={() => {
+      <FileUploader
+        open={openFileModal}
+        onCancel={() => {
           setOpenFileModal(false);
-        }} onUploaded={onAvatarImageSelected} />
+        }}
+        onUploaded={onAvatarImageSelected}
+        onlyFileKind="image"
+      />
       {/*<FileBrowserModal
         open={openFileModal}
         onCancel={() => {

--- a/hook/profile/useDiscordLogin.ts
+++ b/hook/profile/useDiscordLogin.ts
@@ -5,7 +5,7 @@ import { useAuthState } from "../useAuthState";
 
 type UseDiscordLogin = () => {
   loginUrl: string;
-  setCallbackCode: (string) => Promise<boolean>;
+  setCallbackCode: (string) => Promise<void>;
 };
 
 export const useDiscordLogin: UseDiscordLogin = () => {
@@ -32,21 +32,16 @@ export const useDiscordLogin: UseDiscordLogin = () => {
       }
     })();
   }, [authState]);
-  const setCallbackCode = async (code: string): Promise<boolean> => {
-    try {
-      const _ = await axios.put(
-        "/user/me/discord/callback",
-        { code: code },
-        {
-          headers: {
-            Authorization: "Bearer " + authState.token,
-          },
+  const setCallbackCode = async (code: string): Promise<void> => {
+    const _ = await axios.put(
+      "/user/me/discord/callback",
+      { code: code },
+      {
+        headers: {
+          Authorization: "Bearer " + authState.token,
         },
-      );
-      return true;
-    } catch (e: any) {
-      return false;
-    }
+      },
+    );
   };
   return {
     loginUrl,

--- a/interfaces/file.ts
+++ b/interfaces/file.ts
@@ -27,18 +27,47 @@ export type FileKind =
   | "exe"
   | "apk"
   | "other";
+export const imageExts = ["jpeg", "jpg", "png", "gif"];
+export const videoExts = ["mp4"];
+export const textExts = ["txt"]; //後でプログラムコードなども追加する
+export const audioExts = ["mp3", "wav", "m4a"];
+export const singleKinds = ["zip", "pdf", "pptx", "docx", "xlsx", "exe", "apk"];
 export const getFileKind = (ext: string): FileKind => {
-  const imageExts = ["jpeg", "jpg", "png", "gif"];
   if (imageExts.includes(ext.toLocaleLowerCase())) return "image";
-  const videoExts = ["mp4"];
   if (videoExts.includes(ext.toLocaleLowerCase())) return "video";
-  const textExts = ["txt"]; //後でプログラムコードなども追加する
   if (textExts.includes(ext.toLocaleLowerCase())) return "text";
   //modelは後々対応
-  const audioExts = ["mp3", "wav", "m4a"];
   if (audioExts.includes(ext.toLocaleLowerCase())) return "audio";
-  const singleKinds = ["zip", "pdf", "pptx", "docx", "xlsx", "exe", "apk"];
   if (singleKinds.includes(ext.toLocaleLowerCase())) return ext.toLocaleLowerCase() as FileKind;
-
   return "other";
+};
+export const getFileExtWithKind = (kind: FileKind): string[] => {
+  switch (kind) {
+    case "image":
+      return imageExts;
+    case "video":
+      return videoExts;
+    case "text":
+      return textExts;
+    case "model":
+      return [];
+    case "audio":
+      return audioExts;
+    case "zip":
+      return ["zip"];
+    case "pdf":
+      return ["pdf"];
+    case "pptx":
+      return ["pptx"];
+    case "docx":
+      return ["docx"];
+    case "xlsx":
+      return ["xlsx"];
+    case "exe":
+      return ["exe"];
+    case "apk":
+      return ["apk"];
+    default:
+      return [];
+  }
 };

--- a/pages/user/discord/callback.tsx
+++ b/pages/user/discord/callback.tsx
@@ -13,18 +13,20 @@ const DiscordCallbackPage = ({ code, isLoginFailed }: Props) => {
   const { authState, refresh } = useAuthState();
   useEffect(() => {
     if (!authState.isLogined) return;
-    setCallbackCode(code).then((res) => {
-      if (localStorage.getItem("reg_discord") != null) {
-        setTimeout(() => {
-          refresh().then(() => {
-            localStorage.removeItem("reg_discord");
-            router.push("/user/profile?register=true");
-          });
-        }, 1000);
-      } else {
-        router.push("/user/profile");
-      }
-    });
+    setCallbackCode(code)
+      .then(() => {
+        if (localStorage.getItem("reg_discord") != null) {
+          setTimeout(() => {
+            refresh().then(() => {
+              localStorage.removeItem("reg_discord");
+              router.push("/user/profile?register=true");
+            });
+          }, 1000);
+        } else {
+          router.push("/user/profile");
+        }
+      })
+      .catch((e) => console.log(e));
   }, [authState]);
   if (isLoginFailed) return <p>Discord連携に失敗</p>;
   return <>Discord連携作業中...（そのままお待ちください）</>;


### PR DESCRIPTION
## 概要

- [x] 初心者に優しくするために初回登録にてアイコン選択で直接アップローダーが起動するように変更
- [x] discordのcallbackページにて2回目以降のPUTで正しく遷移されなくなる問題への対策

## スクリーンショット（変更の場合は変更前と変更後が分かるように）

<img width="506" alt="image" src="https://user-images.githubusercontent.com/30793866/231799232-c3663ca2-a58a-4cea-9046-999e0ae4bfc2.png">


## 破壊的変更があるか(あれば内容を記載)

- [ ] YES
- [x] NO

## チェック項目

- [x] ビルドが通る
- [x] 作成した機能が想定通りに動作する
- [x] スマートフォンサイズで表示確認を行った
- [ ] warning が増えていない
- [ ] 複雑なコードにはコメントを記載してある
