### PR TITLE
スライドファイルの自動プレビューを抑制

### DIFF
--- a/components/Work/WorkCardPreview.tsx
+++ b/components/Work/WorkCardPreview.tsx
@@ -10,5 +10,5 @@ export const WorkCardPreview = ({ id }: Props) => {
   if (!workDetail) return <p>Loading...</p>;
   if (!workDetail.files || workDetail.files.length === 0)
     return <MarkdownView md={workDetail.description.substring(0, 120)} />;
-  return <WorkFileView fileId={workDetail.files[0].fileId} />;
+  return <WorkFileView fileId={workDetail.files[0].fileId} previewLimit={true} />;
 };

--- a/components/Work/WorkFileView.tsx
+++ b/components/Work/WorkFileView.tsx
@@ -4,6 +4,8 @@ import FileView from "../File/FileView";
 import ElementResizeListener from "../Common/ElementResizeListener";
 import FileKindIcon from "../File/FileKindIcon";
 import { getFileKind } from "../../interfaces/file";
+import { Fab } from "@mui/material";
+import PageviewIcon from "@mui/icons-material/Pageview";
 
 type WorkFileViewProps = {
   fileId: string;
@@ -50,15 +52,16 @@ export const WorkFileView = ({ fileId, previewLimit }: WorkFileViewProps) => {
         <FileKindIcon kind={getFileKind(file.extension)} />
         PowerPointファイル
         <br />
-        <button
-          style={{ margin: 2, padding: 15, cursor: "pointer" }}
+        <Fab
+          variant="extended"
           onClick={(e) => {
             e.stopPropagation();
             setView(true);
           }}
         >
-          クリックして表示
-        </button>
+          <PageviewIcon sx={{ mr: 1 }} />
+          表示
+        </Fab>
       </div>
     );
   return <FileView file={file} />;

--- a/components/Work/WorkFileView.tsx
+++ b/components/Work/WorkFileView.tsx
@@ -1,11 +1,65 @@
+import { useEffect, useRef, useState } from "react";
 import { useFile } from "../../hook/file/useFile";
 import FileView from "../File/FileView";
+import ElementResizeListener from "../Common/ElementResizeListener";
+import FileKindIcon from "../File/FileKindIcon";
+import { getFileKind } from "../../interfaces/file";
 
 type WorkFileViewProps = {
   fileId: string;
+  previewLimit?: boolean;
 };
-export const WorkFileView = ({ fileId }: WorkFileViewProps) => {
+export const WorkFileView = ({ fileId, previewLimit }: WorkFileViewProps) => {
   const file = useFile(fileId);
-  if (!file) return <p>Loading...</p>;
+  const contentRef: React.RefObject<HTMLDivElement> = useRef(null);
+  const [view, setView] = useState(!previewLimit);
+  const [height, setHeight] = useState(100);
+  useEffect(() => {
+    if (!contentRef.current) return;
+    setHeight((contentRef.current.getBoundingClientRect().width * 10) / 16);
+  }, [contentRef]);
+  if (!file)
+    return (
+      <div
+        ref={contentRef}
+        style={{
+          width: "100%",
+          textAlign: "center",
+          height: `${height}px`,
+        }}
+      >
+        <p>Loading...</p>
+      </div>
+    );
+  if (file.extension === "pptx" && !view)
+    return (
+      <div
+        ref={contentRef}
+        style={{
+          width: "100%",
+          textAlign: "center",
+          height: `${height}px`,
+          fontSize: "20px",
+        }}
+      >
+        <ElementResizeListener
+          onResize={(e) => {
+            setHeight((contentRef.current.getBoundingClientRect().width * 10) / 16);
+          }}
+        />
+        <FileKindIcon kind={getFileKind(file.extension)} />
+        PowerPointファイル
+        <br />
+        <button
+          style={{ margin: 2, cursor: "pointer" }}
+          onClick={(e) => {
+            e.stopPropagation();
+            setView(true);
+          }}
+        >
+          クリックして表示
+        </button>
+      </div>
+    );
   return <FileView file={file} />;
 };

--- a/components/Work/WorkFileView.tsx
+++ b/components/Work/WorkFileView.tsx
@@ -51,7 +51,7 @@ export const WorkFileView = ({ fileId, previewLimit }: WorkFileViewProps) => {
         PowerPointファイル
         <br />
         <button
-          style={{ margin: 2, cursor: "pointer" }}
+          style={{ margin: 2, padding: 15, cursor: "pointer" }}
           onClick={(e) => {
             e.stopPropagation();
             setView(true);


### PR DESCRIPTION
## 概要

- [x] Work一覧にてPowerPointの表示までにワンアクション追加
- [x] MUI の Floating Action Button を採用

## スクリーンショット（変更の場合は変更前と変更後が分かるように）

![image](https://user-images.githubusercontent.com/64347376/233112650-f4c46db3-6a3c-4b81-ba00-5a868494c849.png)

## 破壊的変更があるか(あれば内容を記載)

- [ ] YES
- [x] NO

## チェック項目

- [x] ビルドが通る
- [x] 作成した機能が想定通りに動作する
- [x] スマートフォンサイズで表示確認を行った
- [x] warning が増えていない
- [ ] 複雑なコードにはコメントを記載してある
