### PR TITLE
稟議機能

### DIFF
--- a/components/Budget/AdminApproveDialog.tsx
+++ b/components/Budget/AdminApproveDialog.tsx
@@ -25,6 +25,7 @@ export const AdminApproveDialog = ({ open, onClose, onConfirm, name }: Props) =>
       </IconButton>
       <DialogContent dividers sx={{ textAlign: "center" }}>
         <p>稟議「{name}」を承認しますか？</p>
+        <p>変更後は元に戻すことができません！</p>
         <Button variant="contained" color="success" sx={{ marginY: 3 }} onClick={onConfirm}>
           承認
         </Button>

--- a/components/Budget/AdminApproveDialog.tsx
+++ b/components/Budget/AdminApproveDialog.tsx
@@ -1,0 +1,34 @@
+import { Button, Dialog, DialogContent, DialogTitle, IconButton } from "@mui/material";
+import { Close } from "@mui/icons-material";
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  name: string;
+};
+export const AdminApproveDialog = ({ open, onClose, onConfirm, name }: Props) => {
+  return (
+    <Dialog open={open} onClose={onClose}>
+      <DialogTitle>操作の確認</DialogTitle>
+      <IconButton
+        aria-label="close"
+        onClick={onClose}
+        sx={{
+          position: "absolute",
+          right: 12,
+          top: 12,
+          color: (theme) => theme.palette.grey[500],
+        }}
+      >
+        <Close />
+      </IconButton>
+      <DialogContent dividers sx={{ textAlign: "center" }}>
+        <p>稟議「{name}」を承認しますか？</p>
+        <Button variant="contained" color="success" sx={{ marginY: 3 }} onClick={onConfirm}>
+          承認
+        </Button>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/components/Budget/AdminPaidDialog.tsx
+++ b/components/Budget/AdminPaidDialog.tsx
@@ -1,0 +1,35 @@
+import { Button, Dialog, DialogContent, DialogTitle, IconButton } from "@mui/material";
+import { Close } from "@mui/icons-material";
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  name: string;
+};
+export const AdminPaidDialog = ({ open, onClose, onConfirm, name }: Props) => {
+  return (
+    <Dialog open={open} onClose={onClose}>
+      <DialogTitle>操作の確認</DialogTitle>
+      <IconButton
+        aria-label="close"
+        onClick={onClose}
+        sx={{
+          position: "absolute",
+          right: 12,
+          top: 12,
+          color: (theme) => theme.palette.grey[500],
+        }}
+      >
+        <Close />
+      </IconButton>
+      <DialogContent dividers sx={{ textAlign: "center" }}>
+        <p>稟議「{name}」を支払い済みに切り替えますか？</p>
+        <p>変更後は元に戻すことができません！</p>
+        <Button variant="contained" sx={{ marginY: 3 }} onClick={onConfirm}>
+          支払い済みにする
+        </Button>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/components/Budget/AdminPaidDialog.tsx
+++ b/components/Budget/AdminPaidDialog.tsx
@@ -24,10 +24,10 @@ export const AdminPaidDialog = ({ open, onClose, onConfirm, name }: Props) => {
         <Close />
       </IconButton>
       <DialogContent dividers sx={{ textAlign: "center" }}>
-        <p>稟議「{name}」を支払い済みに切り替えますか？</p>
+        <p>稟議「{name}」を支払い完了に切り替えますか？</p>
         <p>変更後は元に戻すことができません！</p>
         <Button variant="contained" sx={{ marginY: 3 }} onClick={onConfirm}>
-          支払い済みにする
+          支払い完了にする
         </Button>
       </DialogContent>
     </Dialog>

--- a/components/Budget/AdminRejectDialog.tsx
+++ b/components/Budget/AdminRejectDialog.tsx
@@ -1,0 +1,34 @@
+import { Button, Dialog, DialogContent, DialogTitle, IconButton } from "@mui/material";
+import { Close } from "@mui/icons-material";
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  name: string;
+};
+export const AdminRejectDialog = ({ open, onClose, onConfirm, name }: Props) => {
+  return (
+    <Dialog open={open} onClose={onClose}>
+      <DialogTitle>操作の確認</DialogTitle>
+      <IconButton
+        aria-label="close"
+        onClick={onClose}
+        sx={{
+          position: "absolute",
+          right: 12,
+          top: 12,
+          color: (theme) => theme.palette.grey[500],
+        }}
+      >
+        <Close />
+      </IconButton>
+      <DialogContent dividers sx={{ textAlign: "center" }}>
+        <p>稟議「{name}」を却下しますか？</p>
+        <Button variant="contained" color="error" sx={{ marginY: 3 }} onClick={onConfirm}>
+          却下
+        </Button>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/components/Budget/AdminRejectDialog.tsx
+++ b/components/Budget/AdminRejectDialog.tsx
@@ -25,6 +25,7 @@ export const AdminRejectDialog = ({ open, onClose, onConfirm, name }: Props) => 
       </IconButton>
       <DialogContent dividers sx={{ textAlign: "center" }}>
         <p>稟議「{name}」を却下しますか？</p>
+        <p>変更後は元に戻すことができません！</p>
         <Button variant="contained" color="error" sx={{ marginY: 3 }} onClick={onConfirm}>
           却下
         </Button>

--- a/components/Budget/BudgetEditor.tsx
+++ b/components/Budget/BudgetEditor.tsx
@@ -1,0 +1,361 @@
+import { Dispatch, SetStateAction, useEffect, useState } from "react";
+import { useAuthState } from "../../hook/useAuthState";
+import { BudgetDetail, BudgetStatus, PutBudgetRequest } from "../../interfaces/budget";
+import { FileObject } from "../../interfaces/file";
+import {
+  Button,
+  Divider,
+  Grid,
+  IconButton,
+  InputAdornment,
+  List,
+  ListItem,
+  TextField,
+} from "@mui/material";
+import DeleteIcon from "@mui/icons-material/Delete";
+import { FileBrowserModal } from "../File/FileBrowser";
+import BudgetListItem from "./BudgetListItem";
+
+type Props = {
+  onSubmit: (budget: any) => void;
+  initBudget?: BudgetDetail;
+};
+
+type Fields = "name" | "purpose" | "budget" | "settlement" | "mattermostUrl" | "remark" | "files";
+
+type FieldFlags = {
+  [K in Fields]?: boolean;
+};
+
+type ValidationErrors = {
+  [K in Fields]?: string;
+};
+
+// status毎の編集可能なフィールドを定義 (trueで編集可能を表す)
+const editableFields: {
+  [K in BudgetStatus]: FieldFlags;
+} = {
+  pending: {
+    name: true,
+    purpose: true,
+    budget: true,
+    mattermostUrl: true,
+    remark: true,
+  },
+  approve: {
+    settlement: true,
+    remark: true,
+    files: true,
+  },
+  bought: {
+    settlement: true,
+    remark: true,
+    files: true,
+  },
+  paid: {
+    remark: true,
+  },
+  reject: {},
+};
+
+const isFilled = (s?: string) => {
+  if (!s) return false;
+  if (s === "") false;
+  return true;
+};
+
+const isInt = (s?: string) => {
+  if (!s) return false;
+  return /^-?\d+$/.test(s);
+};
+
+const BudgetEditor = ({ onSubmit, initBudget }: Props) => {
+  const { authState } = useAuthState();
+  const [name, setName] = useState("");
+  const [budgetStr, setBudgetStr] = useState("");
+  const [mattermostUrl, setMattermostUrl] = useState("");
+  const [purpose, setPurpose] = useState("");
+  const [remark, setRemark] = useState("");
+  const [settlementStr, setSettlementStr] = useState("");
+  const [files, setFiles] = useState<string[]>([]);
+  useEffect(() => {
+    if (!initBudget) return;
+    setName(initBudget.name);
+    setBudgetStr(initBudget.budget.toString());
+    setMattermostUrl(initBudget.mattermostUrl);
+    setPurpose(initBudget.purpose);
+    setRemark(initBudget.remark);
+    setSettlementStr(initBudget.settlement.toString());
+    setFiles(initBudget.files ? initBudget.files.map((f) => f.fileId) : []);
+  }, [initBudget]);
+  const [isOpenFileBrowser, setIsOpenFileBrowser] = useState(false);
+
+  // validator
+  const [errors, setErrors] = useState<ValidationErrors>({});
+  const validateField = (field: Fields, value: string): boolean | string => {
+    switch (field) {
+      case "name":
+        if (!isFilled(value)) return "必須項目です";
+        break;
+      case "purpose":
+        if (!isFilled(value)) return "必須項目です";
+        break;
+      case "budget":
+        // OpenAPI の validator は "validate: required" を指定した場合 0 を許容しない
+        if (!isFilled(value)) return "必須項目です";
+        if (!isInt(value)) return "値は 1 以上の整数である必要があります";
+        if (parseInt(value) < 1) return "値は 1 以上の整数である必要があります";
+        break;
+      case "settlement":
+        if (!isFilled(value)) return "必須項目です";
+        if (!isInt(value)) return "値は 0 以上の整数である必要があります";
+        if (parseInt(value) < 0) return "値は 0 以上の整数である必要があります";
+        break;
+      default:
+        break;
+    }
+    return true;
+  };
+  const handleOnChange = (
+    field: Fields,
+    setState: Dispatch<SetStateAction<typeof value>>,
+    value: string,
+  ) => {
+    setState(value);
+
+    const result = validateField(field, value);
+    if (typeof result === "string") {
+      setErrors({ ...errors, [field]: result });
+    } else {
+      setErrors({ ...errors, [field]: null });
+    }
+  };
+  // 入力可能な必須項目がすべて valid のとき true
+  const isAllValid =
+    (!editableFields[initBudget.status].name || validateField("name", name) === true) &&
+    (!editableFields[initBudget.status].purpose || validateField("purpose", purpose) === true) &&
+    (!editableFields[initBudget.status].budget || validateField("budget", budgetStr) === true) &&
+    (!editableFields[initBudget.status].settlement ||
+      validateField("settlement", settlementStr) === true);
+
+  const onFileSelectCancel = () => {
+    setIsOpenFileBrowser(false);
+  };
+  const onFileSelected = (f: FileObject) => {
+    setIsOpenFileBrowser(false);
+    setFiles([...files, f.fileId]);
+  };
+  const onClickSave = () => {
+    if (!isAllValid) return;
+
+    const budgetRequest: PutBudgetRequest = {
+      name,
+      purpose,
+      mattermostUrl,
+      budget: parseInt(budgetStr),
+      settlement: parseInt(settlementStr),
+      remark,
+      files,
+      bought: false,
+    };
+    onSubmit(budgetRequest);
+  };
+  return (
+    <>
+      <Grid sx={{ marginTop: 3 }}>
+        <h3>基本情報</h3>
+      </Grid>
+      {editableFields[initBudget.status].name ? (
+        <Grid sx={{ marginTop: 3 }}>
+          <TextField
+            required
+            label="稟議名"
+            defaultValue=""
+            value={name}
+            helperText={errors.name}
+            error={!!errors.name}
+            onChange={(e) => {
+              handleOnChange("name", setName, e.target.value);
+            }}
+          />
+        </Grid>
+      ) : (
+        <Grid sx={{ marginTop: 3 }}>
+          <p>稟議名: {name}</p>
+        </Grid>
+      )}
+      {editableFields[initBudget.status].purpose ? (
+        <Grid sx={{ marginTop: 3 }}>
+          <TextField
+            required
+            fullWidth
+            label="利用目的"
+            defaultValue=""
+            value={purpose}
+            helperText={errors.purpose}
+            error={!!errors.purpose}
+            onChange={(e) => {
+              handleOnChange("purpose", setPurpose, e.target.value);
+            }}
+          />
+        </Grid>
+      ) : initBudget.class === "festival" || initBudget.class === "fixed" ? (
+        // 学園祭費または固定費用のときは省略する
+        <></>
+      ) : (
+        <Grid sx={{ marginTop: 3 }}>
+          <p>利用目的: {purpose}</p>
+        </Grid>
+      )}
+      {editableFields[initBudget.status].mattermostUrl ? (
+        <Grid sx={{ marginTop: 3 }}>
+          <TextField
+            fullWidth
+            label="MattermostのURL"
+            helperText="~会計チャンネルのスレッドへのリンクを貼り付けてください"
+            defaultValue=""
+            value={mattermostUrl}
+            onChange={(e) => {
+              handleOnChange("mattermostUrl", setMattermostUrl, e.target.value);
+            }}
+          />
+        </Grid>
+      ) : (
+        <></>
+      )}
+
+      <Divider sx={{ marginTop: 3 }} />
+
+      <Grid sx={{ marginTop: 3 }}>
+        <h3>金額</h3>
+      </Grid>
+      {editableFields[initBudget.status].budget ? (
+        <Grid sx={{ marginTop: 3 }}>
+          <TextField
+            required
+            type="number"
+            label="予定金額"
+            InputProps={{
+              endAdornment: <InputAdornment position="end">円</InputAdornment>,
+            }}
+            defaultValue=""
+            value={budgetStr}
+            helperText={errors.budget}
+            error={!!errors.budget}
+            onChange={(e) => {
+              handleOnChange("budget", setBudgetStr, e.target.value);
+            }}
+          />
+        </Grid>
+      ) : initBudget.class === "festival" || initBudget.class === "fixed" ? (
+        // 学園祭費または固定費用の場合は省略する
+        <></>
+      ) : (
+        <Grid sx={{ marginTop: 3 }}>
+          <p>予定金額: {budgetStr} 円</p>
+        </Grid>
+      )}
+      {editableFields[initBudget.status].settlement ? (
+        <Grid sx={{ marginTop: 3 }}>
+          <TextField
+            required
+            type="number"
+            label="購入金額"
+            InputProps={{
+              endAdornment: <InputAdornment position="end">円</InputAdornment>,
+            }}
+            defaultValue=""
+            value={settlementStr}
+            helperText={errors.settlement}
+            error={!!errors.settlement}
+            onChange={(e) => {
+              handleOnChange("settlement", setSettlementStr, e.target.value);
+            }}
+          />
+        </Grid>
+      ) : initBudget.status === "paid" ? (
+        <Grid sx={{ marginTop: 3 }}>
+          <p>購入金額: {settlementStr} 円</p>
+        </Grid>
+      ) : (
+        <></>
+      )}
+
+      <Divider sx={{ marginTop: 3 }} />
+
+      <Grid sx={{ marginTop: 3 }}>
+        <h3>備考</h3>
+      </Grid>
+      {editableFields[initBudget.status].remark ? (
+        <Grid sx={{ marginTop: 3 }}>
+          <TextField
+            fullWidth
+            label="備考"
+            defaultValue=""
+            value={remark}
+            onChange={(e) => {
+              handleOnChange("remark", setRemark, e.target.value);
+            }}
+          />
+        </Grid>
+      ) : (
+        <></>
+      )}
+      {editableFields[initBudget.status].files ? (
+        <>
+          <Divider sx={{ marginTop: 3 }} />
+
+          <Grid sx={{ marginTop: 3 }}>
+            <h3>領収書</h3>
+            <List>
+              {files.map((fileId) => (
+                <ListItem
+                  key={fileId}
+                  secondaryAction={
+                    <IconButton
+                      edge="end"
+                      aria-label="delete"
+                      onClick={() => {
+                        setFiles(files.filter((f) => f !== fileId));
+                      }}
+                    >
+                      <DeleteIcon />
+                    </IconButton>
+                  }
+                >
+                  {fileId ? <BudgetListItem fileId={fileId} /> : <></>}
+                </ListItem>
+              ))}
+            </List>
+            <Button
+              variant="contained"
+              onClick={() => {
+                setIsOpenFileBrowser(true);
+              }}
+            >
+              ファイルの追加
+            </Button>
+            <FileBrowserModal
+              open={isOpenFileBrowser}
+              onCancel={onFileSelectCancel}
+              onSelected={onFileSelected}
+            />
+          </Grid>
+        </>
+      ) : (
+        <></>
+      )}
+      <Grid sx={{ marginTop: 6, marginBottom: 3, textAlign: "center" }}>
+        {initBudget.status === "reject" ? (
+          <p>この稟議は却下されているため、これ以上編集することができません。</p>
+        ) : (
+          <Button variant="contained" onClick={onClickSave} disabled={!isAllValid}>
+            save
+          </Button>
+        )}
+      </Grid>
+    </>
+  );
+};
+
+export default BudgetEditor;

--- a/components/Budget/BudgetEditor.tsx
+++ b/components/Budget/BudgetEditor.tsx
@@ -81,7 +81,7 @@ const BudgetEditor = ({ onSubmit, initBudget }: Props) => {
   useEffect(() => {
     if (!initBudget) return;
     setName(initBudget.name);
-    setBudgetStr(initBudget.budget.toString());
+    setBudgetStr(initBudget.budget === 0 ? "" : initBudget.budget.toString());
     setMattermostUrl(initBudget.mattermostUrl);
     setPurpose(initBudget.purpose);
     setRemark(initBudget.remark);

--- a/components/Budget/BudgetFileView.tsx
+++ b/components/Budget/BudgetFileView.tsx
@@ -1,0 +1,28 @@
+import { useEffect, useRef, useState } from "react";
+import { useFile } from "../../hook/file/useFile";
+import FileView from "../File/FileView";
+
+type WorkFileViewProps = {
+  fileId: string;
+  previewLimit?: boolean;
+};
+export const BudgetFileView = ({ fileId, previewLimit }: WorkFileViewProps) => {
+  const file = useFile(fileId);
+  const contentRef: React.RefObject<HTMLDivElement> = useRef(null);
+  useEffect(() => {
+    if (!contentRef.current) return;
+  }, [contentRef]);
+  if (!file)
+    return (
+      <div
+        ref={contentRef}
+        style={{
+          width: "100%",
+          textAlign: "center",
+        }}
+      >
+        <p>Loading...</p>
+      </div>
+    );
+  return <FileView file={file} />;
+};

--- a/components/Budget/BudgetListItem.tsx
+++ b/components/Budget/BudgetListItem.tsx
@@ -1,0 +1,27 @@
+import { ListItemIcon, ListItemText } from "@mui/material";
+import { useFile } from "../../hook/file/useFile";
+import { getFileKind } from "../../interfaces/file";
+import FileKindIcon from "../File/FileKindIcon";
+
+type Props = {
+  fileId: string;
+};
+
+const BudgetListItem = ({ fileId }: Props) => {
+  const file = useFile(fileId);
+  if (!file) return <p>Loading...</p>;
+  return (
+    <>
+      {getFileKind(file.extension) === "image" ? (
+        <img src={file.url} alt="" style={{ height: "100px" }} />
+      ) : (
+        <ListItemIcon>
+          <FileKindIcon kind={getFileKind(file.extension)} />
+        </ListItemIcon>
+      )}
+      <ListItemText>{file.name}</ListItemText>
+    </>
+  );
+};
+
+export default BudgetListItem;

--- a/components/Budget/MarkAsBoughtDialog.tsx
+++ b/components/Budget/MarkAsBoughtDialog.tsx
@@ -1,0 +1,39 @@
+import { Button, Dialog, DialogContent, DialogTitle, IconButton } from "@mui/material";
+import { Close } from "@mui/icons-material";
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  name: string;
+};
+export const MarkAsBoughtDialog = ({ open, onClose, onConfirm, name }: Props) => {
+  return (
+    <Dialog open={open} onClose={onClose}>
+      <DialogTitle>操作の確認</DialogTitle>
+      <IconButton
+        aria-label="close"
+        onClick={onClose}
+        sx={{
+          position: "absolute",
+          right: 12,
+          top: 12,
+          color: (theme) => theme.palette.grey[500],
+        }}
+      >
+        <Close />
+      </IconButton>
+      <DialogContent dividers sx={{ textAlign: "center" }}>
+        <p>稟議「{name}」を購入済みに切り替えますか？</p>
+        <p>変更後は元に戻すことができません！</p>
+        <p style={{ fontSize: "small" }}>
+          <br />
+          (変更後も支払いが行われるまでは購入金額・備考・領収書の修正は可能です)
+        </p>
+        <Button variant="contained" sx={{ marginY: 3 }} onClick={onConfirm}>
+          購入済みにする
+        </Button>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/components/Budget/NewBudgetDialog.tsx
+++ b/components/Budget/NewBudgetDialog.tsx
@@ -10,6 +10,7 @@ import {
   Select,
   TextField,
 } from "@mui/material";
+import { Close } from "@mui/icons-material";
 import { useState } from "react";
 import { BudgetClass, CreateBudgetRequest } from "../../interfaces/budget";
 import { useErrorState } from "../../hook/useErrorState";
@@ -62,11 +63,13 @@ export const NewBudgetDialog = ({ open, onClose }: Props) => {
         onClick={onClose}
         sx={{
           position: "absolute",
-          right: 8,
-          top: 8,
+          right: 12,
+          top: 12,
           color: (theme) => theme.palette.grey[500],
         }}
-      ></IconButton>
+      >
+        <Close />
+      </IconButton>
       <DialogContent dividers>
         <FormControl fullWidth sx={{ padding: 2 }}>
           <TextField

--- a/components/Budget/NewBudgetDialog.tsx
+++ b/components/Budget/NewBudgetDialog.tsx
@@ -15,17 +15,28 @@ import { BudgetClass, CreateBudgetRequest } from "../../interfaces/budget";
 import { useErrorState } from "../../hook/useErrorState";
 import { useAuthState } from "../../hook/useAuthState";
 import { useBudgets } from "../../hook/budget/useBudget";
+import { useRouter } from "next/router";
 type Props = {
   open: boolean;
   onClose: () => void;
 };
 const classList: BudgetClass[] = ["room", "project", "outside", "fixed", "festival"];
+const classDisplay: {
+  [K in BudgetClass]: string;
+} = {
+  room: "部室",
+  project: "企画",
+  outside: "学外活動",
+  fixed: "固定費用",
+  festival: "学園祭",
+};
 export const NewBudgetDialog = ({ open, onClose }: Props) => {
   const [inputName, setInputName] = useState("");
   const [inputClass, setInputClass] = useState<BudgetClass | undefined>();
   const { setNewError } = useErrorState();
   const { authState } = useAuthState();
   const { createBudget } = useBudgets();
+  const router = useRouter();
 
   const onClickCreate = () => {
     const name = inputName;
@@ -34,8 +45,9 @@ export const NewBudgetDialog = ({ open, onClose }: Props) => {
       alert("稟議名が空、もしくは種別が指定されていません");
     } else {
       createBudget({ name: name, class: className, proposerUserId: authState.user.userId })
-        .then(() => {
+        .then((budgetId) => {
           onClose();
+          router.push(`/budget/${budgetId}?mode=edit`);
         })
         .catch((e) => {
           setNewError({ name: "post-budget", message: "稟議申請に失敗しました" });
@@ -58,6 +70,7 @@ export const NewBudgetDialog = ({ open, onClose }: Props) => {
       <DialogContent dividers>
         <FormControl fullWidth sx={{ padding: 2 }}>
           <TextField
+            required
             label="稟議名"
             variant="outlined"
             value={inputName}
@@ -66,8 +79,8 @@ export const NewBudgetDialog = ({ open, onClose }: Props) => {
             }}
           />
         </FormControl>
-        <FormControl fullWidth sx={{ padding: 2 }}>
-          <InputLabel>種別</InputLabel>
+        <FormControl fullWidth required sx={{ padding: 2 }}>
+          <InputLabel sx={{ margin: 2 }}>種別</InputLabel>
           <Select
             value={inputClass}
             label="種別"
@@ -75,7 +88,7 @@ export const NewBudgetDialog = ({ open, onClose }: Props) => {
           >
             {classList.map((c) => (
               <MenuItem value={c} key={c}>
-                {c}
+                {classDisplay[c]}
               </MenuItem>
             ))}
           </Select>

--- a/components/Budget/NewBudgetDialog.tsx
+++ b/components/Budget/NewBudgetDialog.tsx
@@ -11,10 +11,10 @@ import {
   TextField,
 } from "@mui/material";
 import { useState } from "react";
-import { BudgetClass } from "../../interfaces/budget";
+import { BudgetClass, CreateBudgetRequest } from "../../interfaces/budget";
 import { useErrorState } from "../../hook/useErrorState";
-import { axios } from "../../utils/axios";
 import { useAuthState } from "../../hook/useAuthState";
+import { useBudgets } from "../../hook/budget/useBudget";
 type Props = {
   open: boolean;
   onClose: () => void;
@@ -25,6 +25,7 @@ export const NewBudgetDialog = ({ open, onClose }: Props) => {
   const [inputClass, setInputClass] = useState<BudgetClass | undefined>();
   const { setNewError } = useErrorState();
   const { authState } = useAuthState();
+  const { createBudget } = useBudgets();
 
   const onClickCreate = () => {
     const name = inputName;
@@ -32,16 +33,7 @@ export const NewBudgetDialog = ({ open, onClose }: Props) => {
     if (name == "" || className == undefined) {
       alert("稟議名が空、もしくは種別が指定されていません");
     } else {
-      axios
-        .post(
-          "/budget",
-          { name: name, class: className },
-          {
-            headers: {
-              Authorization: "Bearer " + authState.token,
-            },
-          },
-        )
+      createBudget({ name: name, class: className, proposerUserId: authState.user.userId })
         .then(() => {
           onClose();
         })

--- a/components/Home/AppMenu.tsx
+++ b/components/Home/AppMenu.tsx
@@ -13,6 +13,7 @@ import { useAuthState } from "../../hook/useAuthState";
 import LoginIcon from "@mui/icons-material/Login";
 import InventoryIcon from "@mui/icons-material/Inventory";
 import CurrencyYenIcon from "@mui/icons-material/CurrencyYen";
+import ReceiptLongIcon from "@mui/icons-material/ReceiptLong";
 
 const appMenuStyle = {
   position: "absolute" as "absolute",
@@ -104,6 +105,13 @@ export default function AppMenu() {
                 name="Payments"
                 onClick={() => {
                   onClickMenuApp("/user/form/payment");
+                }}
+              />
+              <AppMenuButton
+                icon={<ReceiptLongIcon />}
+                name="Budgets"
+                onClick={() => {
+                  onClickMenuApp("/budget");
                 }}
               />
             </>

--- a/hook/budget/useBudget.ts
+++ b/hook/budget/useBudget.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react"
-import { Budget, BudgetDetail, CreateBudgetRequest } from "../../interfaces/budget"
+import { Budget, BudgetDetail, CreateBudgetRequest, PutBudgetRequest, PutBudgetStatusApproveRequest, PutBudgetStatusBoughtRequest, PutBudgetStatusPaidRequest, PutBudgetStatusPendingRequest } from "../../interfaces/budget"
 import { useAuthState } from "../useAuthState";
 import { useErrorState } from "../useErrorState";
 import { axios } from "../../utils/axios";
@@ -9,26 +9,118 @@ export const useBudget = (budgetId: string) => {
   const { authState } = useAuthState();
   const { setNewError, removeError } = useErrorState();
 
+  const fetchBudget = async () => {
+    if (!authState.isLogined) return;
+    try {
+      const res = await axios.get(`/budget/${budgetId}`, {
+        headers: {
+          Authorization: "Bearer " + authState.token,
+        },
+      });
+      const budgetDetail: BudgetDetail = res.data;
+      setBudget(budgetDetail);
+      removeError("budgetdetail-get-fail");
+    } catch (e: any) {
+      setNewError({ name: "budgetdetail-get-fail", message: "稟議の取得に失敗しました" });
+    }
+  }
+
   useEffect(() => {
-    (async () => {
-      if (!authState.isLogined) return;
-      try {
-        const res = await axios.get(`/budget/${budgetId}`, {
-          headers: {
-            Authorization: "Bearer " + authState.token,
-          },
-        });
-        const budgetDetail: BudgetDetail = res.data;
-        setBudget(budgetDetail);
-        removeError("budgetdetail-get-fail");
-      } catch (e: any) {
-        setNewError({ name: "budgetdetail-get-fail", message: "稟議の取得に失敗しました" });
-      }
-    })();
+    fetchBudget();
   }, [authState]);
+
+  const updateBudgetStatusPending = async (budgetRequest: PutBudgetStatusPendingRequest): Promise<boolean> => {
+    try {
+      const body: PutBudgetStatusPendingRequest = {
+        budget: budgetRequest.budget,
+        files: budgetRequest.files,
+        mattermostUrl: budgetRequest.mattermostUrl,
+        name: budgetRequest.name,
+        purpose: budgetRequest.purpose,
+        remark: budgetRequest.remark,
+      };
+      const res = await axios.put(`/budget/${budgetId}/status_pending`, body, {
+        headers: {
+          Authorization: "Bearer " + authState.token,
+        }
+      });
+      removeError("budget-put-fail");
+      await fetchBudget();  // update 後に詳細ページ側の値が更新されないので再度 fetch する
+      return true;
+    } catch (e: any) {
+      setNewError({ name: "budget-put-fail", message: "稟議の更新に失敗しました" })
+      return false;
+    }
+  }
+
+  const updateBudgetStatusApprove = async (budgetRequest: PutBudgetStatusApproveRequest): Promise<boolean> => {
+    try {
+      const body: PutBudgetStatusApproveRequest = {
+        bought: budgetRequest.bought,
+        files: budgetRequest.files,
+        remark: budgetRequest.remark,
+        settlement: budgetRequest.settlement,
+      };
+      const res = await axios.put(`/budget/${budgetId}/status_approve`, body, {
+        headers: {
+          Authorization: "Bearer " + authState.token,
+        }
+      });
+      removeError("budget-put-fail");
+      await fetchBudget();  // update 後に詳細ページ側の値が更新されないので再度 fetch する
+      return true;
+    } catch (e: any) {
+      setNewError({ name: "budget-put-fail", message: "稟議の更新に失敗しました" })
+      return false;
+    }
+  }
+
+  const updateBudgetStatusBought = async (budgetRequest: PutBudgetStatusBoughtRequest): Promise<boolean> => {
+    try {
+      const body: PutBudgetStatusBoughtRequest = {
+        files: budgetRequest.files,
+        remark: budgetRequest.remark,
+        settlement: budgetRequest.settlement,
+      };
+      const res = await axios.put(`/budget/${budgetId}/status_bought`, body, {
+        headers: {
+          Authorization: "Bearer " + authState.token,
+        }
+      });
+      removeError("budget-put-fail");
+      await fetchBudget();  // update 後に詳細ページ側の値が更新されないので再度 fetch する
+      return true;
+    } catch (e: any) {
+      setNewError({ name: "budget-put-fail", message: "稟議の更新に失敗しました" })
+      return false;
+    }
+  }
+
+  const updateBudgetStatusPaid = async (budgetRequest: PutBudgetStatusPaidRequest): Promise<boolean> => {
+    try {
+      const body: PutBudgetStatusPaidRequest = {
+        remark: budgetRequest.remark,
+      };
+      const res = await axios.put(`/budget/${budgetId}/status_paid`, body, {
+        headers: {
+          Authorization: "Bearer " + authState.token,
+        }
+      });
+      removeError("budget-put-fail");
+      await fetchBudget();  // update 後に詳細ページ側の値が更新されないので再度 fetch する
+      return true;
+    } catch (e: any) {
+      setNewError({ name: "budget-put-fail", message: "稟議の更新に失敗しました" })
+      return false;
+    }
+  }
 
   return {
     budgetDetail: budget,
+    updateBudgetStatusPending,
+    updateBudgetStatusApprove,
+    updateBudgetStatusBought,
+    updateBudgetStatusPaid,
   };
 }
 

--- a/hook/budget/useBudget.ts
+++ b/hook/budget/useBudget.ts
@@ -1,8 +1,36 @@
 import { useEffect, useState } from "react"
-import { Budget, CreateBudgetRequest } from "../../interfaces/budget"
+import { Budget, BudgetDetail, CreateBudgetRequest } from "../../interfaces/budget"
 import { useAuthState } from "../useAuthState";
 import { useErrorState } from "../useErrorState";
 import { axios } from "../../utils/axios";
+
+export const useBudget = (budgetId: string) => {
+  const [budget, setBudget] = useState<BudgetDetail>();
+  const { authState } = useAuthState();
+  const { setNewError, removeError } = useErrorState();
+
+  useEffect(() => {
+    (async () => {
+      if (!authState.isLogined) return;
+      try {
+        const res = await axios.get(`/budget/${budgetId}`, {
+          headers: {
+            Authorization: "Bearer " + authState.token,
+          },
+        });
+        const budgetDetail: BudgetDetail = res.data;
+        setBudget(budgetDetail);
+        removeError("budgetdetail-get-fail");
+      } catch (e: any) {
+        setNewError({ name: "budgetdetail-get-fail", message: "稟議の取得に失敗しました" });
+      }
+    })();
+  }, [authState]);
+
+  return {
+    budgetDetail: budget,
+  };
+}
 
 export const useBudgets = () => {
   const [budgets, setBudgets] = useState<Budget[]>([]);

--- a/hook/budget/useBudget.ts
+++ b/hook/budget/useBudget.ts
@@ -165,11 +165,12 @@ export const useBudgets: UseBudgets = (proposerId) => {
   const fetchBudgets = async (n: number): Promise<FetchBudgetsResult> => {
     if (!authState.isLogined) return { isLogined: false };
     try {
-      const res = await axios.get(`/budget?offset=${n}${proposerId ?
-        proposerId === "my"
-          ? `&proposerId=${authState.user.userId!}`
-          : `&proposerId=${proposerId}`
-        : ""
+      const res = await axios.get(
+        `/budget?offset=${n}${proposerId ?
+          proposerId === "my"
+            ? `&proposerId=${authState.user.userId!}`
+            : `&proposerId=${proposerId}`
+          : ""
         }`, {
         headers: {
           Authorization: "Bearer " + authState.token,

--- a/hook/budget/useBudget.ts
+++ b/hook/budget/useBudget.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react"
-import { Budget, BudgetDetail, CreateBudgetRequest, PutBudgetRequest, PutBudgetStatusApproveRequest, PutBudgetStatusBoughtRequest, PutBudgetStatusPaidRequest, PutBudgetStatusPendingRequest } from "../../interfaces/budget"
+import { Budget, BudgetDetail, CreateBudgetRequest, PutBudgetAdminRequest, PutBudgetRequest, PutBudgetStatusApproveRequest, PutBudgetStatusBoughtRequest, PutBudgetStatusPaidRequest, PutBudgetStatusPendingRequest } from "../../interfaces/budget"
 import { useAuthState } from "../useAuthState";
 import { useErrorState } from "../useErrorState";
 import { axios } from "../../utils/axios";
@@ -115,12 +115,32 @@ export const useBudget = (budgetId: string) => {
     }
   }
 
+  const updateAdminBudget = async (budgetRequest: PutBudgetAdminRequest): Promise<boolean> => {
+    try {
+      const body: PutBudgetAdminRequest = {
+        status: budgetRequest.status,
+      };
+      const res = await axios.put(`/budget/${budgetId}/admin`, body, {
+        headers: {
+          Authorization: "Bearer " + authState.token,
+        }
+      });
+      removeError("budget-put-fail");
+      await fetchBudget();
+      return true;
+    } catch (e: any) {
+      setNewError({ name: "budget-put-fail", message: "稟議の更新に失敗しました" });
+      return false;
+    }
+  }
+
   return {
     budgetDetail: budget,
     updateBudgetStatusPending,
     updateBudgetStatusApprove,
     updateBudgetStatusBought,
     updateBudgetStatusPaid,
+    updateAdminBudget,
   };
 }
 

--- a/hook/budget/useBudget.ts
+++ b/hook/budget/useBudget.ts
@@ -1,0 +1,55 @@
+import { useEffect, useState } from "react"
+import { Budget, CreateBudgetRequest } from "../../interfaces/budget"
+import { useAuthState } from "../useAuthState";
+import { useErrorState } from "../useErrorState";
+import { axios } from "../../utils/axios";
+
+export const useBudgets = () => {
+  const [budgets, setBudgets] = useState<Budget[]>([]);
+  const { authState } = useAuthState();
+  const { setNewError, removeError } = useErrorState();
+
+  const fetchBudgets = async () => {
+    if (!authState.isLogined) return;
+    try {
+      const res = await axios.get(`/budget`, {
+        headers: {
+          Authorization: "Bearer " + authState.token,
+        },
+      });
+      const budgets: Budget[] = res.data.budgets;
+      setBudgets(budgets);
+      removeError("budgets-get-fail");
+    } catch (err: any) {
+      setNewError({
+        name: "budgets-get-fail",
+        message: "稟議情報の一覧の取得に失敗しました",
+      });
+    }
+  };
+
+  useEffect(() => {
+    fetchBudgets();
+  }, [authState]);
+
+  const createBudget = async (createBudgetRequest: CreateBudgetRequest): Promise<string> => {
+    if (!authState.isLogined) return "ログインしてください";
+    try {
+      const res = await axios.post(`/budget`, createBudgetRequest, {
+        headers: {
+          Authorization: "Bearer " + authState.token,
+        },
+      });
+      removeError("budget-post-fail");
+      return res.data.budgetId;
+    } catch (err: any) {
+      setNewError({ name: "budget-post-fail", message: "稟議の申請に失敗しました" });
+      return "error";
+    }
+  };
+
+  return {
+    budgets: budgets,
+    createBudget: createBudget,
+  };
+}

--- a/interfaces/budget.ts
+++ b/interfaces/budget.ts
@@ -48,3 +48,31 @@ export type CreateBudgetRequest = {
   class: BudgetClass;
   proposerUserId: string;
 }
+
+export type PutBudgetStatusPendingRequest = {
+  name: string;
+  budget: number;
+  purpose: string;
+  mattermostUrl: string;
+  remark: string;
+  files: string[];
+}
+
+export type PutBudgetStatusApproveRequest = {
+  settlement: number;
+  remark: string;
+  bought: boolean;
+  files: string[];
+}
+
+export type PutBudgetStatusBoughtRequest = {
+  settlement: number;
+  remark: string;
+  files: string[];
+}
+
+export type PutBudgetStatusPaidRequest = {
+  remark: string;
+}
+
+export type PutBudgetRequest = PutBudgetStatusPendingRequest & PutBudgetStatusApproveRequest & PutBudgetStatusBoughtRequest & PutBudgetStatusPaidRequest;

--- a/interfaces/budget.ts
+++ b/interfaces/budget.ts
@@ -76,3 +76,7 @@ export type PutBudgetStatusPaidRequest = {
 }
 
 export type PutBudgetRequest = PutBudgetStatusPendingRequest & PutBudgetStatusApproveRequest & PutBudgetStatusBoughtRequest & PutBudgetStatusPaidRequest;
+
+export type PutBudgetAdminRequest = {
+  status: BudgetStatus;
+}

--- a/interfaces/budget.ts
+++ b/interfaces/budget.ts
@@ -8,6 +8,17 @@ export type BudgetProposer = {
   iconUrl: string;
 }
 
+export type BudgetApprover = {
+  userId: string;
+  username: string;
+  iconUrl: string;
+}
+
+export type BudgetFile = {
+  fileId: string;
+  name: string;
+}
+
 export type Budget = {
   userId: string;
   username: string;
@@ -20,6 +31,16 @@ export type Budget = {
   budget: number;
   updatedAt: string;
   proposer: BudgetProposer;
+}
+
+export type BudgetDetail = Budget & {
+  purpose: string;
+  mattermostUrl: string;
+  approver?: BudgetApprover;
+  files: BudgetFile[];
+  createdAt: string;
+  approvedAt?: string;
+  remark: string;
 }
 
 export type CreateBudgetRequest = {

--- a/interfaces/budget.ts
+++ b/interfaces/budget.ts
@@ -1,1 +1,29 @@
 export type BudgetClass = "festival" | "fixed" | "project" | "outside" | "room";
+
+export type BudgetStatus = "pending" | "reject" | "approve" | "bought" | "paid";
+
+export type BudgetProposer = {
+  userId: string;
+  username: string;
+  iconUrl: string;
+}
+
+export type Budget = {
+  userId: string;
+  username: string;
+  iconUrl: string;
+  budgetId: string;
+  name: string;
+  class: BudgetClass;
+  status: BudgetStatus;
+  settlement: number;
+  budget: number;
+  updatedAt: string;
+  proposer: BudgetProposer;
+}
+
+export type CreateBudgetRequest = {
+  name: string;
+  class: BudgetClass;
+  proposerUserId: string;
+}

--- a/pages/budget/[id].tsx
+++ b/pages/budget/[id].tsx
@@ -397,7 +397,9 @@ const BudgetDetailPage = ({ id, modeStr, error }: Props) => {
                       <TableCell>
                         <Stack spacing={1}>
                           {budgetDetail.files ? (
-                            budgetDetail.files.map((f) => <BudgetFileView fileId={f.fileId} />)
+                            budgetDetail.files.map((f) => (
+                              <BudgetFileView fileId={f.fileId} key={f.fileId} />
+                            ))
                           ) : (
                             <></>
                           )}

--- a/pages/budget/[id].tsx
+++ b/pages/budget/[id].tsx
@@ -2,6 +2,7 @@ import { useBudget } from "../../hook/budget/useBudget";
 import { useAuthState } from "../../hook/useAuthState";
 import { Budget, BudgetStatus } from "../../interfaces/budget";
 import {
+  Button,
   Chip,
   Container,
   Grid,
@@ -17,6 +18,7 @@ import Breadcrumbs from "../../components/Common/Breadcrumb";
 import { GetServerSideProps } from "next";
 import FileView from "../../components/File/FileView";
 import { useFile } from "../../hook/file/useFile";
+import { useRouter } from "next/router";
 
 const budgetStatusColor: {
   [K in BudgetStatus]:
@@ -52,6 +54,7 @@ type Props = {
 };
 
 const BudgetDetailPage = ({ id, modeStr, error }: Props) => {
+  const router = useRouter();
   const { budgetDetail } = useBudget(id);
   const { authState } = useAuthState();
 
@@ -76,7 +79,23 @@ const BudgetDetailPage = ({ id, modeStr, error }: Props) => {
         <>
           <Grid>
             <h1>{budgetDetail.name}</h1>
-            <Chip label={budgetDetail.status} color={budgetStatusColor[budgetDetail.status]} />
+            <div>
+              <Chip label={budgetDetail.status} color={budgetStatusColor[budgetDetail.status]} />
+              {authState.user.userId === budgetDetail.proposer.userId ? (
+                <div style={{ float: "right" }}>
+                  <Button
+                    variant="contained"
+                    onClick={() => {
+                      router.push(`/budget/${budgetDetail.budgetId}?mode=edit`);
+                    }}
+                  >
+                    編集
+                  </Button>
+                </div>
+              ) : (
+                <></>
+              )}
+            </div>
           </Grid>
           <Grid container sx={{ marginTop: 3 }}>
             <TableContainer>
@@ -164,10 +183,12 @@ const BudgetDetailPage = ({ id, modeStr, error }: Props) => {
 
 export default BudgetDetailPage;
 
-export const getServerSideProps: GetServerSideProps = async ({ params }) => {
+export const getServerSideProps: GetServerSideProps = async ({ params, query }) => {
   try {
     const id = params?.id;
-    return { props: { id } };
+    const { mode } = query;
+    const modeStr = typeof mode === "string" ? mode : null;
+    return { props: { id, modeStr } };
   } catch (error) {
     return { props: { errors: error.message } };
   }

--- a/pages/budget/[id].tsx
+++ b/pages/budget/[id].tsx
@@ -1,0 +1,174 @@
+import { useBudget } from "../../hook/budget/useBudget";
+import { useAuthState } from "../../hook/useAuthState";
+import { Budget, BudgetStatus } from "../../interfaces/budget";
+import {
+  Chip,
+  Container,
+  Grid,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableRow,
+} from "@mui/material";
+import PageHead from "../../components/Common/PageHead";
+import Breadcrumbs from "../../components/Common/Breadcrumb";
+import { GetServerSideProps } from "next";
+import FileView from "../../components/File/FileView";
+import { useFile } from "../../hook/file/useFile";
+
+const budgetStatusColor: {
+  [K in BudgetStatus]:
+    | "primary"
+    | "error"
+    | "success"
+    | "warning"
+    | "default"
+    | "secondary"
+    | "info";
+} = {
+  pending: "default",
+  reject: "error",
+  approve: "success",
+  bought: "secondary",
+  paid: "primary",
+};
+
+const dateOptions: Intl.DateTimeFormatOptions = {
+  year: "numeric",
+  month: "numeric",
+  day: "numeric",
+  hour: "2-digit",
+  minute: "2-digit",
+  second: "2-digit",
+};
+
+type Props = {
+  id: string;
+  modeStr?: string;
+  error?: string;
+  budgetPublic?: Budget;
+};
+
+const BudgetDetailPage = ({ id, modeStr, error }: Props) => {
+  const { budgetDetail } = useBudget(id);
+  const { authState } = useAuthState();
+
+  if (!authState.isLogined) return <></>;
+  if (!budgetDetail) return <p>Loading...</p>;
+
+  const files = budgetDetail.files.map((file) => useFile(file.fileId));
+
+  return (
+    <Container>
+      <PageHead title={budgetDetail.name} />
+      <Breadcrumbs
+        links={[
+          { text: "Home", href: "/" },
+          { text: "Budget", href: "/budget" },
+          { text: budgetDetail.name },
+        ]}
+      />
+      {modeStr === "edit" ? (
+        <></>
+      ) : (
+        <>
+          <Grid>
+            <h1>{budgetDetail.name}</h1>
+            <Chip label={budgetDetail.status} color={budgetStatusColor[budgetDetail.status]} />
+          </Grid>
+          <Grid container sx={{ marginTop: 3 }}>
+            <TableContainer>
+              <hr />
+              <Table sx={{ minWidth: 650 }} size="small" aria-label="a dense table">
+                <TableBody>
+                  <TableRow>
+                    <TableCell>種別</TableCell>
+                    <TableCell>{budgetDetail.class}</TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell>利用目的</TableCell>
+                    <TableCell>{budgetDetail.purpose}</TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell>予定金額</TableCell>
+                    <TableCell>{budgetDetail.budget} 円</TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell>購入金額</TableCell>
+                    <TableCell>{budgetDetail.settlement} 円</TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell>備考</TableCell>
+                    <TableCell>{budgetDetail.remark}</TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell>申請者</TableCell>
+                    <TableCell>{budgetDetail.proposer.username}</TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell>申請日時</TableCell>
+                    <TableCell>
+                      {new Date(budgetDetail.createdAt).toLocaleString("ja-JP", dateOptions)}
+                    </TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell>更新日時</TableCell>
+                    <TableCell>
+                      {new Date(budgetDetail.updatedAt).toLocaleString("ja-JP", dateOptions)}
+                    </TableCell>
+                  </TableRow>
+                  {budgetDetail.status === "approve" ||
+                  budgetDetail.status === "bought" ||
+                  budgetDetail.status === "paid" ? (
+                    <>
+                      <TableRow>
+                        <TableCell>承認者</TableCell>
+                        <TableCell>
+                          {budgetDetail.approver.username ||
+                            `(${budgetDetail.class}のため自動承認)`}
+                        </TableCell>
+                      </TableRow>
+                      <TableRow>
+                        <TableCell>承認日時</TableCell>
+                        <TableCell>
+                          {new Date(
+                            budgetDetail.approvedAt || budgetDetail.createdAt,
+                          ).toLocaleString("ja-JP", dateOptions)}
+                        </TableCell>
+                      </TableRow>
+                    </>
+                  ) : (
+                    <></>
+                  )}
+                  <TableRow>
+                    <TableCell>領収書</TableCell>
+                    <TableCell>
+                      <Stack spacing={1} direction="column">
+                        {files.map((fileObj) => (
+                          <FileView file={fileObj} key={fileObj.name} />
+                        ))}
+                      </Stack>
+                    </TableCell>
+                  </TableRow>
+                </TableBody>
+              </Table>
+            </TableContainer>
+          </Grid>
+        </>
+      )}
+    </Container>
+  );
+};
+
+export default BudgetDetailPage;
+
+export const getServerSideProps: GetServerSideProps = async ({ params }) => {
+  try {
+    const id = params?.id;
+    return { props: { id } };
+  } catch (error) {
+    return { props: { errors: error.message } };
+  }
+};

--- a/pages/budget/[id].tsx
+++ b/pages/budget/[id].tsx
@@ -13,6 +13,7 @@ import {
   Container,
   Divider,
   Grid,
+  IconButton,
   Stack,
   Table,
   TableBody,
@@ -20,6 +21,7 @@ import {
   TableContainer,
   TableRow,
 } from "@mui/material";
+import LaunchIcon from "@mui/icons-material/Launch";
 import PageHead from "../../components/Common/PageHead";
 import Breadcrumbs from "../../components/Common/Breadcrumb";
 import { GetServerSideProps } from "next";
@@ -350,6 +352,34 @@ const BudgetDetailPage = ({ id, modeStr, error }: Props) => {
                     <TableCell>備考</TableCell>
                     <TableCell>{budgetDetail.remark}</TableCell>
                   </TableRow>
+                  {budgetDetail.class === "outside" ||
+                  budgetDetail.class === "project" ||
+                  budgetDetail.class === "room" ? (
+                    <TableRow>
+                      <TableCell>スレッド</TableCell>
+                      <TableCell>
+                        {budgetDetail.mattermostUrl &&
+                        new URL(budgetDetail.mattermostUrl).hostname === "mm.digicre.net" ? (
+                          <IconButton
+                            size="small"
+                            title="Mattermostで開く"
+                            onClick={() =>
+                              router.push(
+                                budgetDetail.mattermostUrl.replace(/^http[s]?:/, "mattermost:"),
+                              )
+                            }
+                          >
+                            <LaunchIcon />
+                          </IconButton>
+                        ) : (
+                          <></>
+                        )}
+                      </TableCell>
+                    </TableRow>
+                  ) : (
+                    <></>
+                  )}
+
                   <TableRow>
                     <TableCell>申請者</TableCell>
                     <TableCell>{budgetDetail.proposer.username}</TableCell>

--- a/pages/budget/[id].tsx
+++ b/pages/budget/[id].tsx
@@ -2,6 +2,7 @@ import { useBudget } from "../../hook/budget/useBudget";
 import { useAuthState } from "../../hook/useAuthState";
 import {
   Budget,
+  BudgetClass,
   BudgetStatus,
   PutBudgetAdminRequest,
   PutBudgetRequest,
@@ -31,6 +32,26 @@ import { AdminApproveDialog } from "../../components/Budget/AdminApproveDialog";
 import { AdminRejectDialog } from "../../components/Budget/AdminRejectDialog";
 import { MarkAsBoughtDialog } from "../../components/Budget/MarkAsBoughtDialog";
 import { AdminPaidDialog } from "../../components/Budget/AdminPaidDialog";
+
+const classDisplay: {
+  [K in BudgetClass]: string;
+} = {
+  room: "部室",
+  project: "企画",
+  outside: "学外活動",
+  fixed: "固定費用",
+  festival: "学園祭",
+};
+
+const statusDisplay: {
+  [K in BudgetStatus]: string;
+} = {
+  pending: "申請中",
+  reject: "却下",
+  approve: "承認済み",
+  bought: "購入済み",
+  paid: "支払い完了",
+};
 
 const budgetStatusColor: {
   [K in BudgetStatus]:
@@ -199,7 +220,10 @@ const BudgetDetailPage = ({ id, modeStr, error }: Props) => {
         <>
           <Grid>
             <h1>{budgetDetail.name}</h1>
-            <Chip label={budgetDetail.status} color={budgetStatusColor[budgetDetail.status]} />
+            <Chip
+              label={statusDisplay[budgetDetail.status]}
+              color={budgetStatusColor[budgetDetail.status]}
+            />
           </Grid>
           <BudgetEditor onSubmit={onSubmit} initBudget={budgetDetail} />
         </>
@@ -208,7 +232,10 @@ const BudgetDetailPage = ({ id, modeStr, error }: Props) => {
           <Grid>
             <h1>{budgetDetail.name}</h1>
             <div>
-              <Chip label={budgetDetail.status} color={budgetStatusColor[budgetDetail.status]} />
+              <Chip
+                label={statusDisplay[budgetDetail.status]}
+                color={budgetStatusColor[budgetDetail.status]}
+              />
               {modeStr === "admin" ? (
                 <>
                   {budgetDetail.status === "pending" ? (
@@ -243,7 +270,7 @@ const BudgetDetailPage = ({ id, modeStr, error }: Props) => {
                             setOpenAdminPaidDialog(true);
                           }}
                         >
-                          支払い済みにする
+                          支払い完了にする
                         </Button>
                       </Stack>
                     </>
@@ -291,20 +318,34 @@ const BudgetDetailPage = ({ id, modeStr, error }: Props) => {
                 <TableBody>
                   <TableRow>
                     <TableCell>種別</TableCell>
-                    <TableCell>{budgetDetail.class}</TableCell>
+                    <TableCell>{classDisplay[budgetDetail.class]}</TableCell>
                   </TableRow>
-                  <TableRow>
-                    <TableCell>利用目的</TableCell>
-                    <TableCell>{budgetDetail.purpose}</TableCell>
-                  </TableRow>
-                  <TableRow>
-                    <TableCell>予定金額</TableCell>
-                    <TableCell>{budgetDetail.budget} 円</TableCell>
-                  </TableRow>
-                  <TableRow>
-                    <TableCell>購入金額</TableCell>
-                    <TableCell>{budgetDetail.settlement} 円</TableCell>
-                  </TableRow>
+                  {budgetDetail.class === "outside" ||
+                  budgetDetail.class === "project" ||
+                  budgetDetail.class === "room" ? (
+                    <>
+                      <TableRow>
+                        <TableCell>利用目的</TableCell>
+                        <TableCell>{budgetDetail.purpose}</TableCell>
+                      </TableRow>
+                      <TableRow>
+                        <TableCell>予定金額</TableCell>
+                        <TableCell>{budgetDetail.budget} 円</TableCell>
+                      </TableRow>
+                    </>
+                  ) : (
+                    <></>
+                  )}
+                  {budgetDetail.status === "approve" ||
+                  budgetDetail.status === "bought" ||
+                  budgetDetail.status === "paid" ? (
+                    <TableRow>
+                      <TableCell>購入金額</TableCell>
+                      <TableCell>{budgetDetail.settlement} 円</TableCell>
+                    </TableRow>
+                  ) : (
+                    <></>
+                  )}
                   <TableRow>
                     <TableCell>備考</TableCell>
                     <TableCell>{budgetDetail.remark}</TableCell>
@@ -333,7 +374,7 @@ const BudgetDetailPage = ({ id, modeStr, error }: Props) => {
                         <TableCell>承認者</TableCell>
                         <TableCell>
                           {budgetDetail.approver.username ||
-                            `(${budgetDetail.class}のため自動承認)`}
+                            `(${classDisplay[budgetDetail.class]}のため自動承認)`}
                         </TableCell>
                       </TableRow>
                       <TableRow>
@@ -348,18 +389,24 @@ const BudgetDetailPage = ({ id, modeStr, error }: Props) => {
                   ) : (
                     <></>
                   )}
-                  <TableRow>
-                    <TableCell>領収書</TableCell>
-                    <TableCell>
-                      <Stack spacing={1}>
-                        {budgetDetail.files ? (
-                          budgetDetail.files.map((f) => <BudgetFileView fileId={f.fileId} />)
-                        ) : (
-                          <></>
-                        )}
-                      </Stack>
-                    </TableCell>
-                  </TableRow>
+                  {budgetDetail.status === "approve" ||
+                  budgetDetail.status === "bought" ||
+                  budgetDetail.status === "paid" ? (
+                    <TableRow>
+                      <TableCell>領収書</TableCell>
+                      <TableCell>
+                        <Stack spacing={1}>
+                          {budgetDetail.files ? (
+                            budgetDetail.files.map((f) => <BudgetFileView fileId={f.fileId} />)
+                          ) : (
+                            <></>
+                          )}
+                        </Stack>
+                      </TableCell>
+                    </TableRow>
+                  ) : (
+                    <></>
+                  )}
                 </TableBody>
               </Table>
             </TableContainer>

--- a/pages/budget/[id].tsx
+++ b/pages/budget/[id].tsx
@@ -30,6 +30,7 @@ import { useState } from "react";
 import { AdminApproveDialog } from "../../components/Budget/AdminApproveDialog";
 import { AdminRejectDialog } from "../../components/Budget/AdminRejectDialog";
 import { MarkAsBoughtDialog } from "../../components/Budget/MarkAsBoughtDialog";
+import { AdminPaidDialog } from "../../components/Budget/AdminPaidDialog";
 
 const budgetStatusColor: {
   [K in BudgetStatus]:
@@ -77,6 +78,7 @@ const BudgetDetailPage = ({ id, modeStr, error }: Props) => {
   const { authState } = useAuthState();
   const [openAdminApproveDialog, setOpenAdminApproveDialog] = useState(false);
   const [openAdminRejectDialog, setOpenAdminRejectDialog] = useState(false);
+  const [openAdminPaidDialog, setOpenAdminPaidDialog] = useState(false);
   const [openMarkAsBoughtDialog, setOpenMarkAsBoughtDialog] = useState(false);
 
   const onSubmit = (budgetRequest: PutBudgetRequest) => {
@@ -126,6 +128,15 @@ const BudgetDetailPage = ({ id, modeStr, error }: Props) => {
     });
   };
 
+  const submitAdminPaid = () => {
+    updateAdminBudget({
+      status: "paid",
+    }).then((result) => {
+      if (!result) return;
+      setOpenAdminPaidDialog(false);
+    });
+  };
+
   const submitMarkAsBought = () => {
     updateBudgetStatusApprove({
       bought: true,
@@ -165,6 +176,12 @@ const BudgetDetailPage = ({ id, modeStr, error }: Props) => {
             open={openAdminRejectDialog}
             onClose={() => setOpenAdminRejectDialog(false)}
             onConfirm={() => submitAdminReject()}
+            name={budgetDetail.name}
+          />
+          <AdminPaidDialog
+            open={openAdminPaidDialog}
+            onClose={() => setOpenAdminPaidDialog(false)}
+            onConfirm={() => submitAdminPaid()}
             name={budgetDetail.name}
           />
         </>
@@ -218,7 +235,18 @@ const BudgetDetailPage = ({ id, modeStr, error }: Props) => {
                       </Stack>
                     </>
                   ) : budgetDetail.status === "bought" ? (
-                    <></>
+                    <>
+                      <Stack spacing={3} direction="row" sx={{ marginTop: 3 }}>
+                        <Button
+                          variant="contained"
+                          onClick={() => {
+                            setOpenAdminPaidDialog(true);
+                          }}
+                        >
+                          支払い済みにする
+                        </Button>
+                      </Stack>
+                    </>
                   ) : (
                     <></>
                   )}

--- a/pages/budget/index.tsx
+++ b/pages/budget/index.tsx
@@ -1,12 +1,32 @@
-import { Container, Grid, Button } from "@mui/material";
+import {
+  Container,
+  Grid,
+  Button,
+  TableContainer,
+  Table,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableBody,
+} from "@mui/material";
 import { useRouter } from "next/router";
 import PageHead from "../../components/Common/PageHead";
 import Breadcrumbs from "../../components/Common/Breadcrumb";
 import { NewBudgetDialog } from "../../components/Budget/NewBudgetDialog";
 import { useState } from "react";
+import { useBudgets } from "../../hook/budget/useBudget";
+
+const dateOptions: Intl.DateTimeFormatOptions = {
+  year: "numeric",
+  month: "numeric",
+  day: "numeric",
+  hour: "2-digit",
+  minute: "2-digit",
+};
 
 const BudgetPage = () => {
   const router = useRouter();
+  const { budgets } = useBudgets();
   const [openNewBudgetDialog, setOpenNewBudgetDialog] = useState(false);
   return (
     <Container>
@@ -35,18 +55,37 @@ const BudgetPage = () => {
         </div>
         <hr style={{ clear: "both" }} />
       </Grid>
-      <Grid>
-        <table>
-          <tr>
-            <th>表題</th>
-            <th>状況</th>
-            <th>種別</th>
-            <th>予定金額</th>
-            <th>購入金額</th>
-            <th>申請者</th>
-            <th>申請日</th>
-          </tr>
-        </table>
+      <Grid container>
+        <TableContainer>
+          <Table sx={{ minWidth: 650 }} aria-label="simple table">
+            <TableHead>
+              <TableRow>
+                <TableCell>表題</TableCell>
+                <TableCell>状況</TableCell>
+                <TableCell>種別</TableCell>
+                <TableCell>予定金額</TableCell>
+                <TableCell>購入金額</TableCell>
+                <TableCell>申請者</TableCell>
+                <TableCell>申請日</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {budgets.map((budget) => (
+                <TableRow key={budget.budgetId}>
+                  <TableCell>{budget.name}</TableCell>
+                  <TableCell>{budget.status}</TableCell>
+                  <TableCell>{budget.class}</TableCell>
+                  <TableCell>{budget.budget}</TableCell>
+                  <TableCell>{budget.settlement}</TableCell>
+                  <TableCell>{budget.proposer.username}</TableCell>
+                  <TableCell title={budget.updatedAt}>
+                    {new Date(budget.updatedAt).toLocaleString("ja-JP", dateOptions)}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
       </Grid>
     </Container>
   );

--- a/pages/budget/index.tsx
+++ b/pages/budget/index.tsx
@@ -71,7 +71,13 @@ const BudgetPage = () => {
             </TableHead>
             <TableBody>
               {budgets.map((budget) => (
-                <TableRow key={budget.budgetId}>
+                <TableRow
+                  key={budget.budgetId}
+                  onClick={() => {
+                    router.push(`/budget/${budget.budgetId}`);
+                  }}
+                  className="clickable-gray"
+                >
                   <TableCell>{budget.name}</TableCell>
                   <TableCell>{budget.status}</TableCell>
                   <TableCell>{budget.class}</TableCell>

--- a/pages/budget/index.tsx
+++ b/pages/budget/index.tsx
@@ -71,8 +71,9 @@ type Props = {
 
 const BudgetPage = ({ modeStr, error }: Props) => {
   const router = useRouter();
-  const { budgets } = useBudgets();
+  const { budgets, loadMore } = useBudgets();
   const [openNewBudgetDialog, setOpenNewBudgetDialog] = useState(false);
+  const [showLoadMoreButton, setShowLoadMoreButton] = useState(true);
   return (
     <Container>
       <PageHead title={modeStr === "admin" ? "★ 稟議" : "稟議"} />
@@ -129,55 +130,78 @@ const BudgetPage = ({ modeStr, error }: Props) => {
                 <TableCell>予定金額</TableCell>
                 <TableCell>購入金額</TableCell>
                 <TableCell>申請者</TableCell>
-                <TableCell>申請日</TableCell>
+                <TableCell>最終更新日</TableCell>
               </TableRow>
             </TableHead>
             <TableBody>
-              {budgets.map((budget) => (
-                <TableRow
-                  key={budget.budgetId}
-                  onClick={
-                    modeStr === "admin"
-                      ? () => {
-                          router.push(`/budget/${budget.budgetId}?mode=admin`);
-                        }
-                      : () => {
-                          router.push(`/budget/${budget.budgetId}`);
-                        }
-                  }
-                  className="clickable-gray"
-                >
-                  <TableCell>
-                    {budget.name.length > 20 ? budget.name.substring(0, 20) + "…" : budget.name}
-                  </TableCell>
-                  <TableCell>
-                    <Chip
-                      label={statusDisplay[budget.status]}
-                      color={budgetStatusColor[budget.status]}
-                      size="small"
-                    />
-                  </TableCell>
-                  <TableCell>{classDisplay[budget.class]}</TableCell>
-                  <TableCell>
-                    {budget.class === "festival" || budget.class === "fixed"
-                      ? "-"
-                      : `${budget.budget} 円`}
-                  </TableCell>
-                  <TableCell>
-                    {budget.status === "pending" || budget.status === "reject"
-                      ? "-"
-                      : `${budget.settlement} 円`}
-                  </TableCell>
-                  <TableCell>{budget.proposer.username}</TableCell>
-                  <TableCell title={budget.updatedAt}>
-                    {new Date(budget.updatedAt).toLocaleString("ja-JP", dateOptions)}
-                  </TableCell>
-                </TableRow>
-              ))}
+              {budgets ? (
+                <>
+                  {budgets.map((budget) => (
+                    <TableRow
+                      key={budget.budgetId}
+                      onClick={
+                        modeStr === "admin"
+                          ? () => {
+                              router.push(`/budget/${budget.budgetId}?mode=admin`);
+                            }
+                          : () => {
+                              router.push(`/budget/${budget.budgetId}`);
+                            }
+                      }
+                      className="clickable-gray"
+                    >
+                      <TableCell>
+                        {budget.name.length > 20 ? budget.name.substring(0, 20) + "…" : budget.name}
+                      </TableCell>
+                      <TableCell>
+                        <Chip
+                          label={statusDisplay[budget.status]}
+                          color={budgetStatusColor[budget.status]}
+                          size="small"
+                        />
+                      </TableCell>
+                      <TableCell>{classDisplay[budget.class]}</TableCell>
+                      <TableCell>
+                        {budget.class === "festival" || budget.class === "fixed"
+                          ? "-"
+                          : `${budget.budget} 円`}
+                      </TableCell>
+                      <TableCell>
+                        {budget.status === "pending" || budget.status === "reject"
+                          ? "-"
+                          : `${budget.settlement} 円`}
+                      </TableCell>
+                      <TableCell>{budget.proposer.username}</TableCell>
+                      <TableCell title={budget.updatedAt}>
+                        {new Date(budget.updatedAt).toLocaleString("ja-JP", dateOptions)}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </>
+              ) : (
+                <TableRow>稟議がありません</TableRow>
+              )}
             </TableBody>
           </Table>
         </TableContainer>
       </Grid>
+      {showLoadMoreButton ? (
+        <Grid sx={{ textAlign: "center", marginY: 3 }}>
+          <Button
+            variant="contained"
+            onClick={() => {
+              loadMore().then((result) => {
+                if (!result) return;
+                if (result.isLogined && result.reachedToEnd) setShowLoadMoreButton(false);
+              });
+            }}
+          >
+            Load More
+          </Button>
+        </Grid>
+      ) : (
+        <Grid sx={{ marginBottom: 3 }}></Grid>
+      )}
     </Container>
   );
 };

--- a/pages/budget/index.tsx
+++ b/pages/budget/index.tsx
@@ -8,6 +8,7 @@ import {
   TableRow,
   TableCell,
   TableBody,
+  Chip,
 } from "@mui/material";
 import { useRouter } from "next/router";
 import PageHead from "../../components/Common/PageHead";
@@ -16,6 +17,7 @@ import { NewBudgetDialog } from "../../components/Budget/NewBudgetDialog";
 import { useState } from "react";
 import { useBudgets } from "../../hook/budget/useBudget";
 import { GetServerSideProps } from "next";
+import { BudgetClass, BudgetStatus } from "../../interfaces/budget";
 
 const dateOptions: Intl.DateTimeFormatOptions = {
   year: "numeric",
@@ -23,6 +25,43 @@ const dateOptions: Intl.DateTimeFormatOptions = {
   day: "numeric",
   hour: "2-digit",
   minute: "2-digit",
+};
+
+const classDisplay: {
+  [K in BudgetClass]: string;
+} = {
+  room: "部室",
+  project: "企画",
+  outside: "学外活動",
+  fixed: "固定費用",
+  festival: "学園祭",
+};
+
+const statusDisplay: {
+  [K in BudgetStatus]: string;
+} = {
+  pending: "申請中",
+  reject: "却下",
+  approve: "承認済み",
+  bought: "購入済み",
+  paid: "支払い完了",
+};
+
+const budgetStatusColor: {
+  [K in BudgetStatus]:
+    | "primary"
+    | "error"
+    | "success"
+    | "warning"
+    | "default"
+    | "secondary"
+    | "info";
+} = {
+  pending: "default",
+  reject: "error",
+  approve: "success",
+  bought: "secondary",
+  paid: "primary",
 };
 
 type Props = {
@@ -108,11 +147,27 @@ const BudgetPage = ({ modeStr, error }: Props) => {
                   }
                   className="clickable-gray"
                 >
-                  <TableCell>{budget.name}</TableCell>
-                  <TableCell>{budget.status}</TableCell>
-                  <TableCell>{budget.class}</TableCell>
-                  <TableCell>{budget.budget}</TableCell>
-                  <TableCell>{budget.settlement}</TableCell>
+                  <TableCell>
+                    {budget.name.length > 20 ? budget.name.substring(0, 20) + "…" : budget.name}
+                  </TableCell>
+                  <TableCell>
+                    <Chip
+                      label={statusDisplay[budget.status]}
+                      color={budgetStatusColor[budget.status]}
+                      size="small"
+                    />
+                  </TableCell>
+                  <TableCell>{classDisplay[budget.class]}</TableCell>
+                  <TableCell>
+                    {budget.class === "festival" || budget.class === "fixed"
+                      ? "-"
+                      : `${budget.budget} 円`}
+                  </TableCell>
+                  <TableCell>
+                    {budget.status === "pending" || budget.status === "reject"
+                      ? "-"
+                      : `${budget.settlement} 円`}
+                  </TableCell>
                   <TableCell>{budget.proposer.username}</TableCell>
                   <TableCell title={budget.updatedAt}>
                     {new Date(budget.updatedAt).toLocaleString("ja-JP", dateOptions)}

--- a/pages/budget/my.tsx
+++ b/pages/budget/my.tsx
@@ -71,16 +71,19 @@ type Props = {
 
 const BudgetPage = ({ modeStr, error }: Props) => {
   const router = useRouter();
-  const { budgets, loadMore } = useBudgets();
+  const { budgets, loadMore } = useBudgets("my");
   const [openNewBudgetDialog, setOpenNewBudgetDialog] = useState(false);
   const [showLoadMoreButton, setShowLoadMoreButton] = useState(true);
   return (
     <Container>
-      <PageHead title={modeStr === "admin" ? "★ 稟議" : "稟議"} />
+      <PageHead title={modeStr === "admin" ? "★ 自分の稟議" : "自分の稟議"} />
       <Breadcrumbs
         links={[
           { text: "Home", href: "/" },
-          { text: modeStr === "admin" ? "Budget (ADMIN)" : "Budget" },
+          modeStr === "admin"
+            ? { text: "Budget (ADMIN)", href: "/budget?mode=admin" }
+            : { text: "Budget", href: "/budget" },
+          { text: "My" },
         ]}
       />
       <NewBudgetDialog
@@ -91,7 +94,9 @@ const BudgetPage = ({ modeStr, error }: Props) => {
       />
       <Grid>
         <div>
-          <h1 className="d-inlineblock">{modeStr === "admin" ? "稟議（管理者用）" : "稟議"}</h1>
+          <h1 className="d-inlineblock">
+            {modeStr === "admin" ? "自分の稟議（管理者用）" : "自分の稟議"}
+          </h1>
           <div style={{ float: "right" }}>
             {modeStr === "admin" ? (
               <Button
@@ -115,21 +120,6 @@ const BudgetPage = ({ modeStr, error }: Props) => {
                 新規稟議申請
               </Button>
             )}
-            <Button
-              variant="contained"
-              sx={{ margin: "0.1rem", marginLeft: 1 }}
-              onClick={
-                modeStr === "admin"
-                  ? () => {
-                      router.push(`/budget/my?mode=admin`);
-                    }
-                  : () => {
-                      router.push(`/budget/my`);
-                    }
-              }
-            >
-              自分の稟議
-            </Button>
           </div>
         </div>
         <hr style={{ clear: "both" }} />


### PR DESCRIPTION
## 概要
稟議機能の各ページを作成

- [x] 稟議の一覧表示
- [x] 稟議の新規作成
- [x] 稟議の詳細表示の作成
- [x] 稟議の編集画面の作成
  - [x] `status == pending` の場合
  - [x] `status == paid` の場合
  - [x] `status == bought` の場合
  - [x] `status == approve` の場合
- [x] 稟議の承認画面(Admin)の作成
- [x] デジクリApps(メニュー)に稟議へのリンクを追加 

## スクリーンショット（変更の場合は変更前と変更後が分かるように）
### 稟議一覧画面
![一覧画面変更前](https://github.com/SIT-DigiCre/digicore_v3_frontend/assets/61535180/05728085-da2d-424b-91b6-633dd1aa73bb)
変更前

![一覧画面変更後](https://github.com/SIT-DigiCre/digicore_v3_frontend/assets/61535180/611c33d7-4648-4fa9-a9df-f31361bd6916)
変更後 `<table>`要素ではなくMUIの`<Table>`で描画するよう変更、バックエンドとの繋ぎ込みも行った

![新規作成ウィンドウ1](https://github.com/SIT-DigiCre/digicore_v3_frontend/assets/61535180/dc414f4e-fd0f-4797-b2f3-4b4ea6544512)

![新規作成ウィンドウ2](https://github.com/SIT-DigiCre/digicore_v3_frontend/assets/61535180/2268fbd6-2d39-407a-ac75-4348da9e87e3)
新規作成ウィンドウ

![my](https://github.com/SIT-DigiCre/digicore_v3_frontend/assets/61535180/f571ed21-a6d5-4191-9f83-155b0b4409c9)
`/budget/my` では自分が申請した稟議を絞り込んで確認することができます

### 稟議詳細画面
自分の稟議の場合、右上に編集ボタンが表示されます

![詳細画面-pending](https://github.com/SIT-DigiCre/digicore_v3_frontend/assets/61535180/e75e7111-1ff2-4951-9cd0-067289c5aa42)
pending/申請中

![approve](https://github.com/SIT-DigiCre/digicore_v3_frontend/assets/61535180/bdf131de-8ead-456a-a317-6eacadab29c1)
approve/承認 (通常) 自分の稟議の場合は状態を「購入済み」にするボタンが表示されます

![詳細画面-approve-承認省略](https://github.com/SIT-DigiCre/digicore_v3_frontend/assets/61535180/579a7d6f-b5a6-4d5c-a01d-ebe2cf41c352)
approve/承認 (承認省略(固定費用または学園祭費)の場合, 予定金額・利用目的・スレッドが省略されます)

![reject](https://github.com/SIT-DigiCre/digicore_v3_frontend/assets/61535180/823aa1a0-4532-495f-b11d-bd42b6449330)
reject/却下

![dialog-bought](https://github.com/SIT-DigiCre/digicore_v3_frontend/assets/61535180/97273cc2-92ab-4174-a4b3-cf4264c98908)
状態を「購入済み」にする際に表示される確認ダイアログ

![bought](https://github.com/SIT-DigiCre/digicore_v3_frontend/assets/61535180/7bedecbe-8b42-4bdf-a969-1d257dfe61ba)
bought/購入済み

![paid](https://github.com/SIT-DigiCre/digicore_v3_frontend/assets/61535180/00e1f076-0cbc-432d-9d55-3cb602d9578e)
paid/支払い完了

### 稟議編集画面
![編集画面-pending](https://github.com/SIT-DigiCre/digicore_v3_frontend/assets/61535180/72ace47f-d420-4b8f-bffd-38ce4fc59cc1)
pending/申請中

![編集画面-approve](https://github.com/SIT-DigiCre/digicore_v3_frontend/assets/61535180/8510aa00-0e09-4e56-a32f-086b8f1cb1ef)
approve/承認 (通常) approve以降は購入金額の編集と領収書の添付が可能になります

![編集画面-approve-承認省略](https://github.com/SIT-DigiCre/digicore_v3_frontend/assets/61535180/3bfabd11-1684-41fb-b34d-74996e10840f)
approve/承認 (承認省略の場合)

![編集画面-bought](https://github.com/SIT-DigiCre/digicore_v3_frontend/assets/61535180/52e53912-31a1-42a9-9df2-eba35b800195)
bought/購入済み

![編集画面-paid](https://github.com/SIT-DigiCre/digicore_v3_frontend/assets/61535180/32e8efe5-cf00-4caf-b65f-cbc94f990f75)
paid/支払い完了

![編集画面-reject](https://github.com/SIT-DigiCre/digicore_v3_frontend/assets/61535180/93c65a5b-444e-4633-be37-6aea6bd9bbe7)
reject/却下 (編集不可)

![バリデーション](https://github.com/SIT-DigiCre/digicore_v3_frontend/assets/61535180/ba28421a-a774-4459-8a65-5e8d9eea77b7)
バリデーションの動作例

### 管理者モード
`/budget` 以下ではクエリに `?mode=admin` を設定することで管理者モードが有効になり、管理者向けのAPI(予算の承認等)にアクセスすることができます もちろん適切な権限がないとバックエンド側で書き込み等の操作が弾かれます

![admin-mode](https://github.com/SIT-DigiCre/digicore_v3_frontend/assets/61535180/8e584963-400f-4250-90ce-50acf0debcbd)
管理者モードが有効のとき、タブに表示されるページタイトルの先頭に★が付きます

![admin-pending](https://github.com/SIT-DigiCre/digicore_v3_frontend/assets/61535180/8c420867-0bdc-464e-81be-c20716994c42)
管理者モードでpending/申請中の稟議を開くと、稟議の承認/却下の操作を行うことができます

![admin-bought](https://github.com/SIT-DigiCre/digicore_v3_frontend/assets/61535180/b7d72deb-cef7-4e4a-b66f-db69322972f2)
管理者モードでbought/購入済みの稟議を開くと、稟議を支払い完了にする操作を行うことができます

![admin-dialog-approve](https://github.com/SIT-DigiCre/digicore_v3_frontend/assets/61535180/ddd818a0-ab26-4c9a-8e41-a823039ea87d)
![admin-dialog-reject](https://github.com/SIT-DigiCre/digicore_v3_frontend/assets/61535180/bc98b214-99e9-4008-bc7f-6d756300cf12)
![admin-dialog-paid](https://github.com/SIT-DigiCre/digicore_v3_frontend/assets/61535180/beaba926-4b2b-43b4-8ebe-9ed583b24c67)
承認/却下/支払いの完了を行う際には確認ダイアログが表示されます

![admin-index](https://github.com/SIT-DigiCre/digicore_v3_frontend/assets/61535180/48a49a5a-3f76-4e0d-8bfa-7331c0c9f2de)
管理者モードが有効の時の一覧画面 右上のボタンから管理者モードを無効にすることもできます

### その他
![menu](https://github.com/SIT-DigiCre/digicore_v3_frontend/assets/61535180/e4762eb9-d4e6-4115-9087-06e87ca91c82)
メニューに稟議を追加

## 破壊的変更があるか(あれば内容を記載)

- [ ] YES
- [x] NO

## チェック項目
- [x] ビルドが通る
- [x] 作成した機能が想定通りに動作する
- [x] スマートフォンサイズで表示確認を行った
- [x] ダークモードで表示確認を行った
- [x] warning が増えていない
- [x] 複雑なコードにはコメントを記載してある
