### PR TITLE
他人の稟議で購入済みにするボタンが表示される問題を修正

### DIFF
--- a/pages/budget/[id].tsx
+++ b/pages/budget/[id].tsx
@@ -297,7 +297,8 @@ const BudgetDetailPage = ({ id, modeStr, error }: Props) => {
               ) : (
                 <></>
               )}
-              {budgetDetail.status === "approve" ? (
+              {budgetDetail.status === "approve" &&
+              authState.user.userId === budgetDetail.proposer.userId ? (
                 <Stack spacing={3} direction="row" sx={{ marginTop: 3 }}>
                   <Button
                     variant="contained"


### PR DESCRIPTION
## 概要

- [x] 自分のものではない稟議の詳細ページで購入済みにするボタンが表示されてしまう問題を修正

## スクリーンショット（変更の場合は変更前と変更後が分かるように）
### 修正前
![image](https://github.com/SIT-DigiCre/digicore_v3_frontend/assets/61535180/515c1eb3-7c32-44e2-afa9-558f28a98c72)
### 修正後
![image](https://github.com/SIT-DigiCre/digicore_v3_frontend/assets/61535180/457fc1e9-02bc-46f7-b611-b7d2b8be2515)

## 破壊的変更があるか(あれば内容を記載)

- [ ] YES
- [x] NO

## チェック項目

- [x] ビルドが通る
- [x] 作成した機能が想定通りに動作する
- [x] スマートフォンサイズで表示確認を行った
- [x] ダークモードで表示確認を行った
- [x] warning が増えていない
- [x] 複雑なコードにはコメントを記載してある
