### PR TITLE
稟議の削除ボタンを追加

### DIFF
--- a/components/Budget/DeleteBudgetDialog.tsx
+++ b/components/Budget/DeleteBudgetDialog.tsx
@@ -7,7 +7,7 @@ type Props = {
   onConfirm: () => void;
   name: string;
 };
-export const MarkAsBoughtDialog = ({ open, onClose, onConfirm, name }: Props) => {
+export const DeleteBudgetDialog = ({ open, onClose, onConfirm, name }: Props) => {
   return (
     <Dialog open={open} onClose={onClose}>
       <DialogTitle>操作の確認</DialogTitle>
@@ -24,15 +24,10 @@ export const MarkAsBoughtDialog = ({ open, onClose, onConfirm, name }: Props) =>
         <Close />
       </IconButton>
       <DialogContent dividers sx={{ textAlign: "center" }}>
-        <p>稟議「{name}」を購入済みに切り替えますか？</p>
-        <p>変更後は元に戻すことができません！</p>
-        <p>また購入済みにした稟議は削除できなくなります！</p>
-        <p style={{ fontSize: "small" }}>
-          <br />
-          (変更後も支払いが行われるまでは購入金額・備考・領収書の修正は可能です)
-        </p>
-        <Button variant="contained" sx={{ marginY: 3 }} onClick={onConfirm}>
-          購入済みにする
+        <p>本当に稟議「{name}」を削除しますか？</p>
+        <p>削除後は元に戻すことができません！</p>
+        <Button variant="contained" color="error" sx={{ marginY: 3 }} onClick={onConfirm}>
+          削除する
         </Button>
       </DialogContent>
     </Dialog>

--- a/hook/budget/useBudget.ts
+++ b/hook/budget/useBudget.ts
@@ -134,6 +134,36 @@ export const useBudget = (budgetId: string) => {
     }
   }
 
+  const deleteBudgetStatusPending = async () => {
+    try {
+      const res = await axios.delete(`/budget/${budgetId}/status_pending`, {
+        headers: {
+          Authorization: "Bearer " + authState.token,
+        }
+      });
+      removeError("budget-delete-fail");
+      return true;
+    } catch (e: any) {
+      setNewError({ name: "budget-delete-fail", message: "稟議の削除に失敗しました" });
+      return false;
+    }
+  }
+
+  const deleteBudgetStatusApprove = async () => {
+    try {
+      const res = await axios.delete(`/budget/${budgetId}/status_approve`, {
+        headers: {
+          Authorization: "Bearer " + authState.token,
+        }
+      });
+      removeError("budget-delete-fail");
+      return true;
+    } catch (e: any) {
+      setNewError({ name: "budget-delete-fail", message: "稟議の削除に失敗しました" });
+      return false;
+    }
+  }
+
   return {
     budgetDetail: budget,
     updateBudgetStatusPending,
@@ -141,6 +171,8 @@ export const useBudget = (budgetId: string) => {
     updateBudgetStatusBought,
     updateBudgetStatusPaid,
     updateAdminBudget,
+    deleteBudgetStatusPending,
+    deleteBudgetStatusApprove,
   };
 }
 

--- a/pages/budget/[id].tsx
+++ b/pages/budget/[id].tsx
@@ -34,6 +34,7 @@ import { AdminApproveDialog } from "../../components/Budget/AdminApproveDialog";
 import { AdminRejectDialog } from "../../components/Budget/AdminRejectDialog";
 import { MarkAsBoughtDialog } from "../../components/Budget/MarkAsBoughtDialog";
 import { AdminPaidDialog } from "../../components/Budget/AdminPaidDialog";
+import { DeleteBudgetDialog } from "../../components/Budget/DeleteBudgetDialog";
 
 const classDisplay: {
   [K in BudgetClass]: string;
@@ -97,12 +98,15 @@ const BudgetDetailPage = ({ id, modeStr, error }: Props) => {
     updateBudgetStatusPaid,
     updateBudgetStatusPending,
     updateAdminBudget,
+    deleteBudgetStatusPending,
+    deleteBudgetStatusApprove,
   } = useBudget(id);
   const { authState } = useAuthState();
   const [openAdminApproveDialog, setOpenAdminApproveDialog] = useState(false);
   const [openAdminRejectDialog, setOpenAdminRejectDialog] = useState(false);
   const [openAdminPaidDialog, setOpenAdminPaidDialog] = useState(false);
   const [openMarkAsBoughtDialog, setOpenMarkAsBoughtDialog] = useState(false);
+  const [openDeleteBudgetDialog, setOpenDeleteBudgetDialog] = useState(false);
 
   const onSubmit = (budgetRequest: PutBudgetRequest) => {
     switch (budgetDetail.status) {
@@ -172,6 +176,23 @@ const BudgetDetailPage = ({ id, modeStr, error }: Props) => {
     });
   };
 
+  const submitDelete = () => {
+    switch (budgetDetail.status) {
+      case "pending":
+        deleteBudgetStatusPending().then((result) => {
+          if (!result) return;
+          router.push(`/budget`);
+        });
+        break;
+      case "approve":
+        deleteBudgetStatusApprove().then((result) => {
+          if (!result) return;
+          router.push(`/budget`);
+        });
+        break;
+    }
+  };
+
   if (!authState.isLogined) return <></>;
   if (!budgetDetail) return <p>Loading...</p>;
 
@@ -215,6 +236,12 @@ const BudgetDetailPage = ({ id, modeStr, error }: Props) => {
         open={openMarkAsBoughtDialog}
         onClose={() => setOpenMarkAsBoughtDialog(false)}
         onConfirm={() => submitMarkAsBought()}
+        name={budgetDetail.name}
+      />
+      <DeleteBudgetDialog
+        open={openDeleteBudgetDialog}
+        onClose={() => setOpenDeleteBudgetDialog(false)}
+        onConfirm={() => submitDelete()}
         name={budgetDetail.name}
       />
 
@@ -284,14 +311,29 @@ const BudgetDetailPage = ({ id, modeStr, error }: Props) => {
                 // 通常モード かつ 編集権限がある場合
                 <>
                   <div style={{ float: "right" }}>
-                    <Button
-                      variant="contained"
-                      onClick={() => {
-                        router.push(`/budget/${budgetDetail.budgetId}?mode=edit`);
-                      }}
-                    >
-                      編集
-                    </Button>
+                    <Stack spacing={3} direction="row">
+                      <Button
+                        variant="contained"
+                        onClick={() => {
+                          router.push(`/budget/${budgetDetail.budgetId}?mode=edit`);
+                        }}
+                      >
+                        編集
+                      </Button>
+                      {(budgetDetail.status === "pending" || budgetDetail.status === "approve") && (
+                        <>
+                          <Button
+                            variant="contained"
+                            color="error"
+                            onClick={() => {
+                              setOpenDeleteBudgetDialog(true);
+                            }}
+                          >
+                            削除
+                          </Button>
+                        </>
+                      )}
+                    </Stack>
                   </div>
                 </>
               ) : (


### PR DESCRIPTION
## 概要

- [x] 稟議を削除するためのボタンを追加
  - 誤って作成した稟議を削除する目的のため、申請状況が「申請中」あるいは「承認済み」の場合のみ削除できるようにしています

## スクリーンショット（変更の場合は変更前と変更後が分かるように）
### 稟議詳細画面(申請中)
![image](https://github.com/SIT-DigiCre/digicore_v3_frontend/assets/61535180/031865c1-4862-4b7f-9183-a882f1175907)
変更前

![image](https://github.com/SIT-DigiCre/digicore_v3_frontend/assets/61535180/afa89e6d-11c3-402c-b0fc-b2c202762dcc)
変更後 画面右上に削除ボタンを追加

### 稟議詳細画面(承認済み)
![image](https://github.com/SIT-DigiCre/digicore_v3_frontend/assets/61535180/cfab4872-a0e5-495b-86e9-3c4af1cc824e)
変更前

![image](https://github.com/SIT-DigiCre/digicore_v3_frontend/assets/61535180/97bee885-cec9-493b-906a-921e03a9d6c4)
変更後 画面右上に削除ボタンを追加 (承認省略の場合も同様)

### 「購入済みにする」ダイアログ
![image](https://github.com/SIT-DigiCre/digicore_v3_frontend/assets/61535180/a4450580-dc52-4ca9-a64f-12800b478901)
変更前

![image](https://github.com/SIT-DigiCre/digicore_v3_frontend/assets/61535180/7c51dd10-776d-4884-8cc4-90a473a804c0)
変更後 購入済みに切り替え後は削除できなくなる旨の文章を追加

### 「削除」ダイアログ
![image](https://github.com/SIT-DigiCre/digicore_v3_frontend/assets/61535180/f1e7a7ba-454d-4096-9146-b220a0c230dd)
新規 (共通)

## 破壊的変更があるか(あれば内容を記載)

- [ ] YES
- [x] NO

## チェック項目

- [x] ビルドが通る
- [x] 作成した機能が想定通りに動作する
- [x] スマートフォンサイズで表示確認を行った
- [x] ダークモードで表示確認を行った
- [x] warning が増えていない
- [x] 複雑なコードにはコメントを記載してある
