### PR TITLE
稟議を購入済みにする際に領収書の添付を必須化 (frontend)

### DIFF
--- a/components/Budget/AdminPaidDialog.tsx
+++ b/components/Budget/AdminPaidDialog.tsx
@@ -1,4 +1,4 @@
-import { Button, Dialog, DialogContent, DialogTitle, IconButton } from "@mui/material";
+import { Button, Dialog, DialogContent, DialogTitle, IconButton, Typography } from "@mui/material";
 import { Close } from "@mui/icons-material";
 
 type Props = {
@@ -6,8 +6,9 @@ type Props = {
   onClose: () => void;
   onConfirm: () => void;
   name: string;
+  filesMissing?: boolean;
 };
-export const AdminPaidDialog = ({ open, onClose, onConfirm, name }: Props) => {
+export const AdminPaidDialog = ({ open, onClose, onConfirm, name, filesMissing }: Props) => {
   return (
     <Dialog open={open} onClose={onClose}>
       <DialogTitle>操作の確認</DialogTitle>
@@ -26,6 +27,19 @@ export const AdminPaidDialog = ({ open, onClose, onConfirm, name }: Props) => {
       <DialogContent dividers sx={{ textAlign: "center" }}>
         <p>稟議「{name}」を支払い完了に切り替えますか？</p>
         <p>変更後は元に戻すことができません！</p>
+        {filesMissing && (
+          <Typography
+            color="error"
+            sx={{
+              marginBlock: "1em",
+            }}
+          >
+            <p>この稟議には領収書が添付されていません。</p>
+            <p>強制的に支払い完了操作を行うことは可能ですが、</p>
+            <p>特別な事情がある場合を除き申請者が領収書を添付してから</p>
+            <p>この操作を行うようにしてください。</p>
+          </Typography>
+        )}
         <Button variant="contained" sx={{ marginY: 3 }} onClick={onConfirm}>
           支払い完了にする
         </Button>

--- a/pages/budget/[id].tsx
+++ b/pages/budget/[id].tsx
@@ -294,7 +294,7 @@ const BudgetDetailPage = ({ id, modeStr, error }: Props) => {
                     </>
                   ) : budgetDetail.status === "bought" ? (
                     <>
-                      <Stack spacing={2} direction="row" sx={{ marginTop: 3 }}>
+                      <Stack direction="row" sx={{ marginTop: 3, gap: 2 }} flexWrap="wrap">
                         <Button
                           variant="contained"
                           onClick={() => {
@@ -349,7 +349,7 @@ const BudgetDetailPage = ({ id, modeStr, error }: Props) => {
               )}
               {budgetDetail.status === "approve" &&
               authState.user.userId === budgetDetail.proposer.userId ? (
-                <Stack spacing={2} direction="row" sx={{ marginTop: 3 }}>
+                <Stack direction="row" sx={{ marginTop: 3, gap: 2 }} flexWrap="wrap">
                   <Button
                     variant="contained"
                     onClick={() => {

--- a/pages/budget/[id].tsx
+++ b/pages/budget/[id].tsx
@@ -20,7 +20,6 @@ import {
   TableCell,
   TableContainer,
   TableRow,
-  Typography,
 } from "@mui/material";
 import LaunchIcon from "@mui/icons-material/Launch";
 import PageHead from "../../components/Common/PageHead";

--- a/pages/budget/[id].tsx
+++ b/pages/budget/[id].tsx
@@ -20,6 +20,7 @@ import {
   TableCell,
   TableContainer,
   TableRow,
+  Typography,
 } from "@mui/material";
 import LaunchIcon from "@mui/icons-material/Launch";
 import PageHead from "../../components/Common/PageHead";
@@ -35,6 +36,7 @@ import { AdminRejectDialog } from "../../components/Budget/AdminRejectDialog";
 import { MarkAsBoughtDialog } from "../../components/Budget/MarkAsBoughtDialog";
 import { AdminPaidDialog } from "../../components/Budget/AdminPaidDialog";
 import { DeleteBudgetDialog } from "../../components/Budget/DeleteBudgetDialog";
+import { ErrorOutline, WarningAmber } from "@mui/icons-material";
 
 const classDisplay: {
   [K in BudgetClass]: string;
@@ -227,6 +229,7 @@ const BudgetDetailPage = ({ id, modeStr, error }: Props) => {
             onClose={() => setOpenAdminPaidDialog(false)}
             onConfirm={() => submitAdminPaid()}
             name={budgetDetail.name}
+            filesMissing={budgetDetail.files.length === 0}
           />
         </>
       ) : (
@@ -292,7 +295,7 @@ const BudgetDetailPage = ({ id, modeStr, error }: Props) => {
                     </>
                   ) : budgetDetail.status === "bought" ? (
                     <>
-                      <Stack spacing={3} direction="row" sx={{ marginTop: 3 }}>
+                      <Stack spacing={2} direction="row" sx={{ marginTop: 3 }}>
                         <Button
                           variant="contained"
                           onClick={() => {
@@ -301,6 +304,12 @@ const BudgetDetailPage = ({ id, modeStr, error }: Props) => {
                         >
                           支払い完了にする
                         </Button>
+                        {budgetDetail.files.length === 0 && (
+                          <Stack spacing={0.5} direction="row" alignItems="center" color="#d32f2f">
+                            <ErrorOutline color="error" fontSize="small" />
+                            <p>この稟議には領収書が添付されていません</p>
+                          </Stack>
+                        )}
                       </Stack>
                     </>
                   ) : (
@@ -341,15 +350,22 @@ const BudgetDetailPage = ({ id, modeStr, error }: Props) => {
               )}
               {budgetDetail.status === "approve" &&
               authState.user.userId === budgetDetail.proposer.userId ? (
-                <Stack spacing={3} direction="row" sx={{ marginTop: 3 }}>
+                <Stack spacing={2} direction="row" sx={{ marginTop: 3 }}>
                   <Button
                     variant="contained"
                     onClick={() => {
                       setOpenMarkAsBoughtDialog(true);
                     }}
+                    disabled={budgetDetail.files.length === 0}
                   >
                     購入済みにする
                   </Button>
+                  {budgetDetail.files.length === 0 && (
+                    <Stack spacing={0.5} direction="row" alignItems="center" color="#ed6c02">
+                      <WarningAmber fontSize="inherit" color="warning" />
+                      <p>購入済みにするには「編集」から領収書の添付が必要です</p>
+                    </Stack>
+                  )}
                 </Stack>
               ) : (
                 <></>


### PR DESCRIPTION
## 概要

- [x] 稟議機能の機能改善
  - [x] (一般部員画面) 稟議に領収書が添付されていない場合、ステータスを購入済みにする操作を行えないように
  - [x] (幹部画面) 稟議に領収書が添付されていない場合、ステータスを支払い済みにする操作を行おうとするときに警告文を表示するように

## スクリーンショット（変更の場合は変更前と変更後が分かるように）
### 稟議詳細画面 (通常)
![image](https://github.com/user-attachments/assets/a5b0088b-f394-4ed7-8b58-bd51e6f4af5f)
稟議に領収書が添付されていない場合、警告文を表示しボタンを無効化

### 稟議詳細画面 (管理者モード)
![image](https://github.com/user-attachments/assets/25fea5fd-9db6-4d87-9e0e-050b508fbfdf)
稟議に領収書が添付されていない場合、警告文を表示

![image](https://github.com/user-attachments/assets/9f68b2e4-7625-4581-8bba-fe2e6f0a85fd)
稟議に領収書が添付されていない場合、警告文を表示

## 破壊的変更があるか(あれば内容を記載)

- [ ] YES
- [x] NO

## チェック項目

- [x] ビルドが通る
- [x] 作成した機能が想定通りに動作する
- [x] スマートフォンサイズで表示確認を行った
- [x] ダークモードで表示確認を行った
- [x] warning が増えていない
- [ ] 複雑なコードにはコメントを記載してある
