### PR TITLE
AppBarのメニューのハイライトを修正

### DIFF
--- a/components/Home/AppBar.tsx
+++ b/components/Home/AppBar.tsx
@@ -83,7 +83,7 @@ export default function AppBar({ children, window }: AppBarProps) {
       label: "ホーム",
     },
     {
-      href: "/user/profile/public",
+      href: "/user/profile",
       icon: <ManageAccountsIcon />,
       label: "プロフィール",
     },


### PR DESCRIPTION
## 変更点

`/profile`以下の`/profile/public`以外のページで、AppBar内のメニュー項目がハイライトされない問題を修正