### PR TITLE
fix: 作品ページ上の作者へのリンクを修正

### DIFF
--- a/pages/work/[id].tsx
+++ b/pages/work/[id].tsx
@@ -113,7 +113,7 @@ const WorkDetailPage = ({ id, modeStr, workPublic }: WorkDetailPageProps) => {
                 workDetail.authors.map((a) => (
                   <ButtonLink
                     startIcon={<Avatar src={a.iconUrl} className="d-inlineblock" />}
-                    href={`/user/${a.userId}`}
+                    href={`/member/${a.userId}`}
                     key={a.userId}
                     variant="text"
                   >


### PR DESCRIPTION
close #146 

## 概要

- 作品ページ上の作者へのリンクを `/user/` から `/member/` に修正しました
