### PR TITLE
feat: 3月中の部費振込に対応する

### DIFF
--- a/utils/date-util.ts
+++ b/utils/date-util.ts
@@ -28,6 +28,6 @@ export const getTimeSpanText = (start: string, end: string) => {
   return `${startDate.format("YYYY/MM/DD")}(${getDayText(startDate)}) ${getTimeText(startDate)} 〜 ${endDate.format("MM/DD")}(${getDayText(endDate)}) ${getTimeText(endDate)}`;
 };
 
-//年度を計算する
+// 年度を計算する（3月中の部費振込に対応するため、3月を翌年度とする）
 export const getFiscalYear = (date: Date): number =>
   date.getMonth() < 2 ? date.getFullYear() - 1 : date.getFullYear();


### PR DESCRIPTION
## 概要

- `getFiscalYear()`で3月を翌年度と扱うように変更した

## 確認

2026年3月10日時点で以下の挙動となることを確認した。

- [x] 2026年度の部費振込報告ができる
- [x] 振込報告一覧で2026年度の振込報告が表示される