### PR TITLE
fix: アクティビティ訪問履歴APIの期間指定変更に対応

### DIFF
--- a/components/Activity/VisitHistorySection.tsx
+++ b/components/Activity/VisitHistorySection.tsx
@@ -45,11 +45,9 @@ const getMondayOfWeek = (dateStr: string) => {
   return d.subtract(day - 1, "day");
 };
 
-// TODO: バックエンドの実装が「指定日の1週間前の週を返す」ようになっていて分かりづらいので修正する
 const getPeriodLabel = (dateStr: string, period: string): string => {
   const d = dayjs(dateStr);
   if (period === "week") {
-    // URLの日付が含まれる週の月曜〜日曜を表示
     const monday = getMondayOfWeek(dateStr);
     const sunday = monday.add(6, "day");
     return `${monday.format("MM/DD")}（月）〜 ${sunday.format("MM/DD")}（日）`;

--- a/components/Error/AdminPageError.tsx
+++ b/components/Error/AdminPageError.tsx
@@ -1,0 +1,23 @@
+import Link from "next/link";
+
+import { Stack, Typography } from "@mui/material";
+
+import Heading from "@/components/Common/Heading";
+
+type AdminPageErrorProps = {
+  message: string;
+  title: string;
+};
+
+const AdminPageError = ({ message, title }: AdminPageErrorProps) => {
+  return (
+    <Stack spacing={2}>
+      <Heading level={2}>{title}</Heading>
+      <Typography>
+        {message} <Link href="/">トップページ</Link>
+      </Typography>
+    </Stack>
+  );
+};
+
+export default AdminPageError;

--- a/components/Home/AccessControl.tsx
+++ b/components/Home/AccessControl.tsx
@@ -5,23 +5,10 @@ import { Stack, Typography } from "@mui/material";
 
 import Heading from "@/components/Common/Heading";
 import { useAuthState } from "@/hook/useAuthState";
-import { GRANT_ACCOUNT, GRANT_INFRA } from "@/utils/auth/grants";
+import { getRequiredAdminGrantsByPath } from "@/utils/auth/admin";
 
 type AccessControlProps = {
   children: React.ReactNode;
-};
-
-const getRequiredAdminGrantsByPath = (pathname: string): string[] | null => {
-  if (!pathname.startsWith("/admin")) return null;
-  if (pathname === "/admin") return [GRANT_ACCOUNT, GRANT_INFRA];
-  if (pathname.startsWith("/admin/budget")) return [GRANT_ACCOUNT];
-  if (pathname.startsWith("/admin/group")) return [GRANT_INFRA];
-  if (pathname.startsWith("/admin/payment")) return [GRANT_ACCOUNT];
-  if (pathname.startsWith("/admin/grade-update")) return [GRANT_INFRA];
-  if (pathname.startsWith("/admin/reentry")) return [GRANT_INFRA];
-  if (pathname.startsWith("/admin/activity")) return [GRANT_INFRA];
-  if (pathname.startsWith("/admin/infra")) return [GRANT_INFRA];
-  return [GRANT_ACCOUNT, GRANT_INFRA];
 };
 
 const AccessControl = ({ children }: AccessControlProps) => {

--- a/pages/activity/[placeId]/index.tsx
+++ b/pages/activity/[placeId]/index.tsx
@@ -25,6 +25,32 @@ import { createServerApiClient } from "@/utils/fetch/client";
 const VALID_PERIODS = ["day", "week", "month"] as const;
 type Period = (typeof VALID_PERIODS)[number];
 
+const getHistoryRange = (date: string, period: Period) => {
+  const baseDate = dayjs(date);
+
+  if (period === "week") {
+    const dayOfWeek = baseDate.day() || 7;
+    const start = baseDate.subtract(dayOfWeek - 1, "day").startOf("day");
+    const end = start.add(6, "day").endOf("day");
+    return {
+      endAt: end.format("YYYY-MM-DDTHH:mm:ssZ"),
+      startAt: start.format("YYYY-MM-DDTHH:mm:ssZ"),
+    };
+  }
+
+  if (period === "month") {
+    return {
+      endAt: baseDate.endOf("month").format("YYYY-MM-DDTHH:mm:ssZ"),
+      startAt: baseDate.startOf("month").format("YYYY-MM-DDTHH:mm:ssZ"),
+    };
+  }
+
+  return {
+    endAt: baseDate.endOf("day").format("YYYY-MM-DDTHH:mm:ssZ"),
+    startAt: baseDate.startOf("day").format("YYYY-MM-DDTHH:mm:ssZ"),
+  };
+};
+
 export const getServerSideProps = async ({ req, query, params }: GetServerSidePropsContext) => {
   const client = createServerApiClient(req);
   const placeId = typeof params?.placeId === "string" ? params.placeId : DEFAULT_PLACE;
@@ -74,14 +100,7 @@ export const getServerSideProps = async ({ req, query, params }: GetServerSidePr
   }
 
   const currentUserId = userRes.data?.userId ?? null;
-
-  // APIは指定日付の1週間前/1ヶ月前のデータを返すため、URLの日付と表示を一致させるためにオフセットする
-  let apiDate = date;
-  if (period === "week") {
-    apiDate = dayjs(date).add(7, "day").format("YYYY-MM-DD");
-  } else if (period === "month") {
-    apiDate = dayjs(date).add(1, "month").format("YYYY-MM-DD");
-  }
+  const { startAt, endAt } = getHistoryRange(date, period);
 
   const [activityRes, historyRes] = await Promise.all([
     client.GET("/activity/place/{place}/current", {
@@ -92,7 +111,7 @@ export const getServerSideProps = async ({ req, query, params }: GetServerSidePr
     client.GET("/activity/place/{place}/history", {
       params: {
         path: { place },
-        query: { date: apiDate, period },
+        query: { endAt, startAt },
       },
     }),
   ]);

--- a/pages/admin/activity/index.tsx
+++ b/pages/admin/activity/index.tsx
@@ -1,4 +1,4 @@
-import type { GetServerSidePropsContext, InferGetServerSidePropsType } from "next";
+import type { GetServerSidePropsContext } from "next";
 import { useRouter } from "next/router";
 import { Fragment } from "react";
 
@@ -24,50 +24,30 @@ import ForceCheckoutButton from "@/components/Activity/ForceCheckoutButton";
 import { ButtonLink } from "@/components/Common/ButtonLink";
 import Heading from "@/components/Common/Heading";
 import PageHead from "@/components/Common/PageHead";
+import AdminPageError from "@/components/Error/AdminPageError";
 import { ACTIVITY_PLACES, DEFAULT_PLACE } from "@/interfaces/activity";
-import { GRANT_INFRA } from "@/utils/auth/grants";
-import { createServerApiClient } from "@/utils/fetch/client";
+import { requireAdminPageAccess } from "@/utils/auth/admin";
+
+import type { AdminPageGuardProps } from "@/utils/auth/admin";
+
+type AdminActivityPageProps = AdminPageGuardProps & {
+  error: string | null;
+  place: string;
+  users: any[];
+};
 
 export const getServerSideProps = async ({ req, query }: GetServerSidePropsContext) => {
-  const client = createServerApiClient(req);
   const rawPlace = typeof query.place === "string" ? query.place : DEFAULT_PLACE;
   const place = Object.hasOwn(ACTIVITY_PLACES, rawPlace) ? rawPlace : DEFAULT_PLACE;
 
+  const accessResult = await requireAdminPageAccess(req, "/admin/activity");
+  if (!accessResult.ok) {
+    return accessResult.result;
+  }
+
+  const { client } = accessResult;
+
   try {
-    const grantsRes = await client.GET("/user/me/grants", {});
-
-    if (grantsRes.error) {
-      const status = grantsRes.response.status;
-
-      if (status === 401 || status === 403) {
-        return {
-          redirect: {
-            destination: "/login",
-            permanent: false,
-          },
-        };
-      }
-
-      console.error("Failed to fetch grants:", grantsRes.error);
-      return {
-        props: {
-          error: `権限情報の取得に失敗しました (HTTP ${status})`,
-          place,
-          users: [],
-        },
-      };
-    }
-
-    const grants = Array.from(
-      new Set(
-        (grantsRes.data?.grants ?? []).map((grant) => grant.trim()).filter((grant) => grant !== ""),
-      ),
-    );
-
-    if (!grants.includes(GRANT_INFRA)) {
-      return { notFound: true };
-    }
-
     const activityRes = await client.GET("/activity/place/{place}/current", {
       params: {
         path: { place },
@@ -89,6 +69,7 @@ export const getServerSideProps = async ({ req, query }: GetServerSidePropsConte
       console.error("Failed to fetch current users:", activityRes.error);
       return {
         props: {
+          adminPageError: null,
           error: `在室情報の取得に失敗しました (HTTP ${status})`,
           place,
           users: [],
@@ -99,6 +80,7 @@ export const getServerSideProps = async ({ req, query }: GetServerSidePropsConte
     if (!activityRes.data) {
       return {
         props: {
+          adminPageError: null,
           error: "在室情報の取得に失敗しました",
           place,
           users: [],
@@ -108,6 +90,7 @@ export const getServerSideProps = async ({ req, query }: GetServerSidePropsConte
 
     return {
       props: {
+        adminPageError: null,
         error: null,
         place,
         users: activityRes.data.users ?? [],
@@ -117,6 +100,7 @@ export const getServerSideProps = async ({ req, query }: GetServerSidePropsConte
     console.error("Failed to fetch current activity users:", error);
     return {
       props: {
+        adminPageError: null,
         error: "在室情報の取得に失敗しました",
         place,
         users: [],
@@ -125,12 +109,17 @@ export const getServerSideProps = async ({ req, query }: GetServerSidePropsConte
   }
 };
 
-const AdminActivityPage = ({
-  users,
-  place,
-  error,
-}: InferGetServerSidePropsType<typeof getServerSideProps>) => {
+const AdminActivityPage = ({ users, place, error, adminPageError }: AdminActivityPageProps) => {
   const router = useRouter();
+
+  if (adminPageError) {
+    return (
+      <>
+        <PageHead title="[管理者用] エラー" />
+        <AdminPageError title={adminPageError.title} message={adminPageError.message} />
+      </>
+    );
+  }
 
   const handlePlaceChange = (newPlace: string) => {
     void router.push({
@@ -187,7 +176,7 @@ const AdminActivityPage = ({
           {users.length > 0 ? (
             <Paper variant="outlined">
               <List disablePadding>
-                {users.map((user, index) => (
+                {users.map((user: any, index: number) => (
                   <Fragment key={user.userId}>
                     {index > 0 && <Divider component="li" />}
                     <ListItem

--- a/pages/admin/activity/index.tsx
+++ b/pages/admin/activity/index.tsx
@@ -28,12 +28,13 @@ import AdminPageError from "@/components/Error/AdminPageError";
 import { ACTIVITY_PLACES, DEFAULT_PLACE } from "@/interfaces/activity";
 import { requireAdminPageAccess } from "@/utils/auth/admin";
 
+import type { ActivityCurrentUser } from "@/interfaces/activity";
 import type { AdminPageGuardProps } from "@/utils/auth/admin";
 
 type AdminActivityPageProps = AdminPageGuardProps & {
   error: string | null;
   place: string;
-  users: any[];
+  users: ActivityCurrentUser[];
 };
 
 export const getServerSideProps = async ({ req, query }: GetServerSidePropsContext) => {
@@ -176,7 +177,7 @@ const AdminActivityPage = ({ users, place, error, adminPageError }: AdminActivit
           {users.length > 0 ? (
             <Paper variant="outlined">
               <List disablePadding>
-                {users.map((user: any, index: number) => (
+                {users.map((user, index: number) => (
                   <Fragment key={user.userId}>
                     {index > 0 && <Divider component="li" />}
                     <ListItem

--- a/pages/admin/budget/[id].tsx
+++ b/pages/admin/budget/[id].tsx
@@ -30,9 +30,13 @@ import { budgetStatusColor, classDisplay, statusDisplay } from "../../../utils/b
 import { apiClient } from "../../../utils/fetch/client";
 
 import type { AdminPageGuardProps } from "../../../utils/auth/admin";
+import type { components } from "../../../utils/fetch/api.d.ts";
+
+type BudgetDetail = components["schemas"]["ResGetBudgetBudgetId"];
+type BudgetDetailFile = components["schemas"]["ResGetBudgetBudgetIdObjectFile"];
 
 type PageProps = AdminPageGuardProps & {
-  budget: any;
+  budget: BudgetDetail;
   budgetId: string;
 };
 
@@ -269,7 +273,7 @@ const AdminBudgetDetailPage = ({ budgetId, budget, adminPageError }: PageProps) 
                     <TableCell>
                       <Stack spacing={1} maxWidth="min(500px, 50vw)">
                         {budget.files &&
-                          budget.files.map((f: any) => (
+                          budget.files.map((f: BudgetDetailFile) => (
                             <BudgetFileView fileId={f.fileId} key={f.fileId} />
                           ))}
                         {budget.files.length === 0 && (

--- a/pages/admin/budget/[id].tsx
+++ b/pages/admin/budget/[id].tsx
@@ -1,4 +1,4 @@
-import type { InferGetServerSidePropsType, NextApiRequest } from "next";
+import type { NextApiRequest } from "next";
 import { useRouter } from "next/router";
 import { useState } from "react";
 
@@ -23,11 +23,18 @@ import { BudgetFileView } from "../../../components/Budget/BudgetFileView";
 import { ButtonLink } from "../../../components/Common/ButtonLink";
 import Heading from "../../../components/Common/Heading";
 import PageHead from "../../../components/Common/PageHead";
+import AdminPageError from "../../../components/Error/AdminPageError";
 import { useAuthState } from "../../../hook/useAuthState";
+import { requireAdminPageAccess } from "../../../utils/auth/admin";
 import { budgetStatusColor, classDisplay, statusDisplay } from "../../../utils/budget/constants";
-import { apiClient, createServerApiClient } from "../../../utils/fetch/client";
+import { apiClient } from "../../../utils/fetch/client";
 
-type PageProps = InferGetServerSidePropsType<typeof getServerSideProps>;
+import type { AdminPageGuardProps } from "../../../utils/auth/admin";
+
+type PageProps = AdminPageGuardProps & {
+  budget: any;
+  budgetId: string;
+};
 
 export const getServerSideProps = async ({
   params,
@@ -40,7 +47,12 @@ export const getServerSideProps = async ({
   const budgetId = typeof idParam === "string" ? idParam : "";
   if (!budgetId) return { notFound: true };
 
-  const client = createServerApiClient(req);
+  const accessResult = await requireAdminPageAccess(req, "/admin/budget");
+  if (!accessResult.ok) {
+    return accessResult.result;
+  }
+
+  const { client } = accessResult;
   try {
     const budgetRes = await client.GET("/budget/{budgetId}", {
       params: {
@@ -54,6 +66,7 @@ export const getServerSideProps = async ({
     }
     return {
       props: {
+        adminPageError: null,
         budget: budgetRes.data,
         budgetId,
       },
@@ -64,13 +77,22 @@ export const getServerSideProps = async ({
   }
 };
 
-const AdminBudgetDetailPage = ({ budgetId, budget }: PageProps) => {
+const AdminBudgetDetailPage = ({ budgetId, budget, adminPageError }: PageProps) => {
   const router = useRouter();
   const { authState } = useAuthState();
 
   const [openAdminApproveDialog, setOpenAdminApproveDialog] = useState(false);
   const [openAdminRejectDialog, setOpenAdminRejectDialog] = useState(false);
   const [openAdminPaidDialog, setOpenAdminPaidDialog] = useState(false);
+
+  if (adminPageError) {
+    return (
+      <>
+        <PageHead title="[管理者用] エラー" />
+        <AdminPageError title={adminPageError.title} message={adminPageError.message} />
+      </>
+    );
+  }
 
   const updateAdminBudget = (status: "approve" | "reject" | "paid") => {
     apiClient
@@ -247,7 +269,7 @@ const AdminBudgetDetailPage = ({ budgetId, budget }: PageProps) => {
                     <TableCell>
                       <Stack spacing={1} maxWidth="min(500px, 50vw)">
                         {budget.files &&
-                          budget.files.map((f) => (
+                          budget.files.map((f: any) => (
                             <BudgetFileView fileId={f.fileId} key={f.fileId} />
                           ))}
                         {budget.files.length === 0 && (

--- a/pages/admin/budget/[id].tsx
+++ b/pages/admin/budget/[id].tsx
@@ -16,21 +16,21 @@ import {
 } from "@mui/material";
 import dayjs from "dayjs";
 
-import { AdminApproveDialog } from "../../../components/Budget/AdminApproveDialog";
-import { AdminPaidDialog } from "../../../components/Budget/AdminPaidDialog";
-import { AdminRejectDialog } from "../../../components/Budget/AdminRejectDialog";
-import { BudgetFileView } from "../../../components/Budget/BudgetFileView";
-import { ButtonLink } from "../../../components/Common/ButtonLink";
-import Heading from "../../../components/Common/Heading";
-import PageHead from "../../../components/Common/PageHead";
-import AdminPageError from "../../../components/Error/AdminPageError";
-import { useAuthState } from "../../../hook/useAuthState";
-import { requireAdminPageAccess } from "../../../utils/auth/admin";
-import { budgetStatusColor, classDisplay, statusDisplay } from "../../../utils/budget/constants";
-import { apiClient } from "../../../utils/fetch/client";
+import { AdminApproveDialog } from "@/components/Budget/AdminApproveDialog";
+import { AdminPaidDialog } from "@/components/Budget/AdminPaidDialog";
+import { AdminRejectDialog } from "@/components/Budget/AdminRejectDialog";
+import { BudgetFileView } from "@/components/Budget/BudgetFileView";
+import { ButtonLink } from "@/components/Common/ButtonLink";
+import Heading from "@/components/Common/Heading";
+import PageHead from "@/components/Common/PageHead";
+import AdminPageError from "@/components/Error/AdminPageError";
+import { useAuthState } from "@/hook/useAuthState";
+import { requireAdminPageAccess } from "@/utils/auth/admin";
+import { budgetStatusColor, classDisplay, statusDisplay } from "@/utils/budget/constants";
+import { apiClient } from "@/utils/fetch/client";
 
-import type { AdminPageGuardProps } from "../../../utils/auth/admin";
-import type { components } from "../../../utils/fetch/api.d.ts";
+import type { AdminPageGuardProps } from "@/utils/auth/admin";
+import type { components } from "@/utils/fetch/api.d.ts";
 
 type BudgetDetail = components["schemas"]["ResGetBudgetBudgetId"];
 type BudgetDetailFile = components["schemas"]["ResGetBudgetBudgetIdObjectFile"];

--- a/pages/admin/budget/index.tsx
+++ b/pages/admin/budget/index.tsx
@@ -24,10 +24,13 @@ import { requireAdminPageAccess } from "../../../utils/auth/admin";
 import { budgetStatusColor, classDisplay, statusDisplay } from "../../../utils/budget/constants";
 
 import type { AdminPageGuardProps } from "../../../utils/auth/admin";
+import type { components } from "../../../utils/fetch/api.d.ts";
 
 const ITEMS_PER_PAGE = 10;
+type BudgetListItem = components["schemas"]["ResGetBudgetObjectBudget"];
+
 type AdminBudgetIndexPageProps = AdminPageGuardProps & {
-  budgets: any[];
+  budgets: BudgetListItem[];
   currentPage: number;
   hasNextPage: boolean;
   hasPreviousPage: boolean;
@@ -133,7 +136,7 @@ const AdminBudgetIndexPage = ({
                   </TableRow>
                 </TableHead>
                 <TableBody>
-                  {budgets.map((budget: any) => (
+                  {budgets.map((budget) => (
                     <TableRow key={budget.budgetId}>
                       <TableCell>
                         <Link href={`/admin/budget/${budget.budgetId}`}>{budget.name}</Link>

--- a/pages/admin/budget/index.tsx
+++ b/pages/admin/budget/index.tsx
@@ -16,15 +16,15 @@ import {
 } from "@mui/material";
 import dayjs from "dayjs";
 
-import { ButtonLink } from "../../../components/Common/ButtonLink";
-import PageHead from "../../../components/Common/PageHead";
-import Pagination from "../../../components/Common/Pagination";
-import AdminPageError from "../../../components/Error/AdminPageError";
-import { requireAdminPageAccess } from "../../../utils/auth/admin";
-import { budgetStatusColor, classDisplay, statusDisplay } from "../../../utils/budget/constants";
+import { ButtonLink } from "@/components/Common/ButtonLink";
+import PageHead from "@/components/Common/PageHead";
+import Pagination from "@/components/Common/Pagination";
+import AdminPageError from "@/components/Error/AdminPageError";
+import { requireAdminPageAccess } from "@/utils/auth/admin";
+import { budgetStatusColor, classDisplay, statusDisplay } from "@/utils/budget/constants";
 
-import type { AdminPageGuardProps } from "../../../utils/auth/admin";
-import type { components } from "../../../utils/fetch/api.d.ts";
+import type { AdminPageGuardProps } from "@/utils/auth/admin";
+import type { components } from "@/utils/fetch/api.d.ts";
 
 const ITEMS_PER_PAGE = 10;
 type BudgetListItem = components["schemas"]["ResGetBudgetObjectBudget"];

--- a/pages/admin/budget/index.tsx
+++ b/pages/admin/budget/index.tsx
@@ -1,4 +1,4 @@
-import type { InferGetServerSidePropsType, NextApiRequest } from "next";
+import type { NextApiRequest } from "next";
 import Link from "next/link";
 import { useRouter } from "next/router";
 
@@ -19,10 +19,19 @@ import dayjs from "dayjs";
 import { ButtonLink } from "../../../components/Common/ButtonLink";
 import PageHead from "../../../components/Common/PageHead";
 import Pagination from "../../../components/Common/Pagination";
+import AdminPageError from "../../../components/Error/AdminPageError";
+import { requireAdminPageAccess } from "../../../utils/auth/admin";
 import { budgetStatusColor, classDisplay, statusDisplay } from "../../../utils/budget/constants";
-import { createServerApiClient } from "../../../utils/fetch/client";
+
+import type { AdminPageGuardProps } from "../../../utils/auth/admin";
 
 const ITEMS_PER_PAGE = 10;
+type AdminBudgetIndexPageProps = AdminPageGuardProps & {
+  budgets: any[];
+  currentPage: number;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+};
 
 export const getServerSideProps = async ({
   req,
@@ -31,7 +40,12 @@ export const getServerSideProps = async ({
   req: NextApiRequest;
   query: { page: string };
 }) => {
-  const client = createServerApiClient(req);
+  const accessResult = await requireAdminPageAccess(req, "/admin/budget");
+  if (!accessResult.ok) {
+    return accessResult.result;
+  }
+
+  const { client } = accessResult;
   const page = query.page ? parseInt(query.page as string, 10) : 1;
   const offset = (page - 1) * ITEMS_PER_PAGE;
 
@@ -44,17 +58,35 @@ export const getServerSideProps = async ({
       },
     });
     if (!budgetsRes.data || !budgetsRes.data.budgets) {
-      return { props: { budgets: [], currentPage: 1, hasNextPage: false, hasPreviousPage: false } };
+      return {
+        props: {
+          adminPageError: null,
+          budgets: [],
+          currentPage: 1,
+          hasNextPage: false,
+          hasPreviousPage: false,
+        },
+      };
     }
 
     const budgets = budgetsRes.data.budgets;
     const hasNextPage = budgets.length === ITEMS_PER_PAGE;
     const hasPreviousPage = page > 1;
 
-    return { props: { budgets, currentPage: page, hasNextPage, hasPreviousPage } };
+    return {
+      props: { adminPageError: null, budgets, currentPage: page, hasNextPage, hasPreviousPage },
+    };
   } catch (error) {
     console.error("Failed to fetch budgets:", error);
-    return { props: { budgets: [], currentPage: 1, hasNextPage: false, hasPreviousPage: false } };
+    return {
+      props: {
+        adminPageError: null,
+        budgets: [],
+        currentPage: 1,
+        hasNextPage: false,
+        hasPreviousPage: false,
+      },
+    };
   }
 };
 
@@ -63,8 +95,18 @@ const AdminBudgetIndexPage = ({
   currentPage,
   hasNextPage,
   hasPreviousPage,
-}: InferGetServerSidePropsType<typeof getServerSideProps>) => {
+  adminPageError,
+}: AdminBudgetIndexPageProps) => {
   const router = useRouter();
+
+  if (adminPageError) {
+    return (
+      <>
+        <PageHead title="[管理者用] エラー" />
+        <AdminPageError title={adminPageError.title} message={adminPageError.message} />
+      </>
+    );
+  }
 
   return (
     <>
@@ -91,7 +133,7 @@ const AdminBudgetIndexPage = ({
                   </TableRow>
                 </TableHead>
                 <TableBody>
-                  {budgets.map((budget) => (
+                  {budgets.map((budget: any) => (
                     <TableRow key={budget.budgetId}>
                       <TableCell>
                         <Link href={`/admin/budget/${budget.budgetId}`}>{budget.name}</Link>

--- a/pages/admin/grade-update/index.tsx
+++ b/pages/admin/grade-update/index.tsx
@@ -1,4 +1,4 @@
-import type { InferGetServerSidePropsType, NextApiRequest } from "next";
+import type { NextApiRequest } from "next";
 import { useRouter } from "next/router";
 import { useState } from "react";
 
@@ -21,38 +21,56 @@ import dayjs from "dayjs";
 import { ButtonLink } from "@/components/Common/ButtonLink";
 import PageHead from "@/components/Common/PageHead";
 import { useErrorState } from "@/components/contexts/ErrorStateContext";
+import AdminPageError from "@/components/Error/AdminPageError";
 import { useAuthState } from "@/hook/useAuthState";
+import { requireAdminPageAccess } from "@/utils/auth/admin";
 import { getRequestStatusChipProps } from "@/utils/chip/requestStatus";
-import { apiClient, createServerApiClient } from "@/utils/fetch/client";
+import { apiClient } from "@/utils/fetch/client";
 
-import type { components } from "@/utils/fetch/api";
+import type { AdminPageGuardProps } from "@/utils/auth/admin";
+import type { components } from "@/utils/fetch/api.d.ts";
 
 type GradeUpdateRequest = components["schemas"]["ResGetAdminGradeUpdateObjectGradeUpdate"];
+type AdminGradeUpdatePageProps = AdminPageGuardProps & {
+  gradeUpdates: GradeUpdateRequest[];
+};
 
 export const getServerSideProps = async ({ req }: { req: NextApiRequest }) => {
-  const client = createServerApiClient(req);
+  const accessResult = await requireAdminPageAccess(req, "/admin/grade-update");
+  if (!accessResult.ok) {
+    return accessResult.result;
+  }
+
+  const { client } = accessResult;
 
   try {
     const response = await client.GET("/admin/grade-update");
 
     if (!response.data || !response.data.gradeUpdates) {
-      return { props: { gradeUpdates: [] } };
+      return { props: { adminPageError: null, gradeUpdates: [] } };
     }
 
-    return { props: { gradeUpdates: response.data.gradeUpdates } };
+    return { props: { adminPageError: null, gradeUpdates: response.data.gradeUpdates } };
   } catch (error) {
     console.error("Failed to fetch grade update requests:", error);
-    return { props: { gradeUpdates: [] } };
+    return { props: { adminPageError: null, gradeUpdates: [] } };
   }
 };
 
-const AdminGradeUpdatePage = ({
-  gradeUpdates,
-}: InferGetServerSidePropsType<typeof getServerSideProps>) => {
+const AdminGradeUpdatePage = ({ gradeUpdates, adminPageError }: AdminGradeUpdatePageProps) => {
   const router = useRouter();
   const { authState } = useAuthState();
   const { setNewError, removeError } = useErrorState();
   const [isLoading, setIsLoading] = useState(false);
+
+  if (adminPageError) {
+    return (
+      <>
+        <PageHead title="[管理者用] エラー" />
+        <AdminPageError title={adminPageError.title} message={adminPageError.message} />
+      </>
+    );
+  }
 
   const updateStatus = async (gradeUpdateId: string, status: "approved" | "rejected") => {
     if (!authState.token || isLoading) {

--- a/pages/admin/group/[id].tsx
+++ b/pages/admin/group/[id].tsx
@@ -1,4 +1,4 @@
-import type { InferGetServerSidePropsType, NextApiRequest } from "next";
+import type { NextApiRequest } from "next";
 import Link from "next/link";
 
 import { ArrowBack } from "@mui/icons-material";
@@ -19,8 +19,17 @@ import {
 import { ButtonLink } from "../../../components/Common/ButtonLink";
 import Heading from "../../../components/Common/Heading";
 import PageHead from "../../../components/Common/PageHead";
+import AdminPageError from "../../../components/Error/AdminPageError";
 import AddUserDialog from "../../../components/Group/AddUserDialog";
-import { createServerApiClient } from "../../../utils/fetch/client";
+import { requireAdminPageAccess } from "../../../utils/auth/admin";
+import { GRANT_INFRA } from "../../../utils/auth/grants";
+
+import type { AdminPageGuardProps } from "../../../utils/auth/admin";
+
+type AdminGroupDetailPageProps = AdminPageGuardProps & {
+  canManageMembers: boolean;
+  group: any;
+};
 
 export const getServerSideProps = async ({
   req,
@@ -29,12 +38,18 @@ export const getServerSideProps = async ({
   req: NextApiRequest;
   params: { id: string };
 }) => {
-  const client = createServerApiClient(req);
   const groupId = params?.id as string;
 
   if (!groupId) {
     return { notFound: true };
   }
+
+  const accessResult = await requireAdminPageAccess(req, "/admin/group");
+  if (!accessResult.ok) {
+    return accessResult.result;
+  }
+
+  const { client, grants } = accessResult;
 
   try {
     const groupRes = await client.GET("/group/{groupId}", {
@@ -49,7 +64,13 @@ export const getServerSideProps = async ({
       return { notFound: true };
     }
 
-    return { props: { group: groupRes.data } };
+    return {
+      props: {
+        adminPageError: null,
+        canManageMembers: groupRes.data.joined || grants.includes(GRANT_INFRA),
+        group: groupRes.data,
+      },
+    };
   } catch (error) {
     console.error("Failed to fetch group:", error);
     return { notFound: true };
@@ -58,7 +79,18 @@ export const getServerSideProps = async ({
 
 const AdminGroupDetailPage = ({
   group,
-}: InferGetServerSidePropsType<typeof getServerSideProps>) => {
+  adminPageError,
+  canManageMembers,
+}: AdminGroupDetailPageProps) => {
+  if (adminPageError) {
+    return (
+      <>
+        <PageHead title="[管理者用] エラー" />
+        <AdminPageError title={adminPageError.title} message={adminPageError.message} />
+      </>
+    );
+  }
+
   return (
     <>
       <PageHead title="[管理者用] グループ詳細" />
@@ -67,7 +99,7 @@ const AdminGroupDetailPage = ({
           <ButtonLink href="/admin/group" startIcon={<ArrowBack />} variant="text">
             グループ一覧に戻る
           </ButtonLink>
-          {group.joined && <AddUserDialog groupId={group.groupId} />}
+          {canManageMembers && <AddUserDialog groupId={group.groupId} />}
         </Stack>
         <Box>
           <Heading level={2}>{group.name}</Heading>
@@ -100,7 +132,7 @@ const AdminGroupDetailPage = ({
                   </TableRow>
                 </TableHead>
                 <TableBody>
-                  {group.users.map((user) => (
+                  {group.users.map((user: any) => (
                     <TableRow key={user.userId}>
                       <TableCell>
                         <Avatar src={user.userIcon} sx={{ height: 40, width: 40 }}>

--- a/pages/admin/group/[id].tsx
+++ b/pages/admin/group/[id].tsx
@@ -16,16 +16,16 @@ import {
   Typography,
 } from "@mui/material";
 
-import { ButtonLink } from "../../../components/Common/ButtonLink";
-import Heading from "../../../components/Common/Heading";
-import PageHead from "../../../components/Common/PageHead";
-import AdminPageError from "../../../components/Error/AdminPageError";
-import AddUserDialog from "../../../components/Group/AddUserDialog";
-import { requireAdminPageAccess } from "../../../utils/auth/admin";
-import { GRANT_INFRA } from "../../../utils/auth/grants";
+import { ButtonLink } from "@/components/Common/ButtonLink";
+import Heading from "@/components/Common/Heading";
+import PageHead from "@/components/Common/PageHead";
+import AdminPageError from "@/components/Error/AdminPageError";
+import AddUserDialog from "@/components/Group/AddUserDialog";
+import { requireAdminPageAccess } from "@/utils/auth/admin";
+import { GRANT_INFRA } from "@/utils/auth/grants";
 
-import type { AdminPageGuardProps } from "../../../utils/auth/admin";
-import type { components } from "../../../utils/fetch/api.d.ts";
+import type { AdminPageGuardProps } from "@/utils/auth/admin";
+import type { components } from "@/utils/fetch/api.d.ts";
 
 type GroupDetail = components["schemas"]["ResGetGroupGroupId"];
 type GroupDetailUser = components["schemas"]["ResGetGroupGroupIdObjectUser"];

--- a/pages/admin/group/[id].tsx
+++ b/pages/admin/group/[id].tsx
@@ -25,10 +25,14 @@ import { requireAdminPageAccess } from "../../../utils/auth/admin";
 import { GRANT_INFRA } from "../../../utils/auth/grants";
 
 import type { AdminPageGuardProps } from "../../../utils/auth/admin";
+import type { components } from "../../../utils/fetch/api.d.ts";
+
+type GroupDetail = components["schemas"]["ResGetGroupGroupId"];
+type GroupDetailUser = components["schemas"]["ResGetGroupGroupIdObjectUser"];
 
 type AdminGroupDetailPageProps = AdminPageGuardProps & {
   canManageMembers: boolean;
-  group: any;
+  group: GroupDetail;
 };
 
 export const getServerSideProps = async ({
@@ -132,7 +136,7 @@ const AdminGroupDetailPage = ({
                   </TableRow>
                 </TableHead>
                 <TableBody>
-                  {group.users.map((user: any) => (
+                  {group.users.map((user: GroupDetailUser) => (
                     <TableRow key={user.userId}>
                       <TableCell>
                         <Avatar src={user.userIcon} sx={{ height: 40, width: 40 }}>

--- a/pages/admin/group/index.tsx
+++ b/pages/admin/group/index.tsx
@@ -14,14 +14,14 @@ import {
   Typography,
 } from "@mui/material";
 
-import { ButtonLink } from "../../../components/Common/ButtonLink";
-import Heading from "../../../components/Common/Heading";
-import PageHead from "../../../components/Common/PageHead";
-import AdminPageError from "../../../components/Error/AdminPageError";
-import { requireAdminPageAccess } from "../../../utils/auth/admin";
+import { ButtonLink } from "@/components/Common/ButtonLink";
+import Heading from "@/components/Common/Heading";
+import PageHead from "@/components/Common/PageHead";
+import AdminPageError from "@/components/Error/AdminPageError";
+import { requireAdminPageAccess } from "@/utils/auth/admin";
 
-import type { AdminPageGuardProps } from "../../../utils/auth/admin";
-import type { components } from "../../../utils/fetch/api.d.ts";
+import type { AdminPageGuardProps } from "@/utils/auth/admin";
+import type { components } from "@/utils/fetch/api.d.ts";
 
 type GroupListItem = components["schemas"]["ResGetGroupObjectGroup"];
 

--- a/pages/admin/group/index.tsx
+++ b/pages/admin/group/index.tsx
@@ -1,4 +1,4 @@
-import type { InferGetServerSidePropsType, NextApiRequest } from "next";
+import type { NextApiRequest } from "next";
 import Link from "next/link";
 
 import { Add, ArrowBack } from "@mui/icons-material";
@@ -17,10 +17,22 @@ import {
 import { ButtonLink } from "../../../components/Common/ButtonLink";
 import Heading from "../../../components/Common/Heading";
 import PageHead from "../../../components/Common/PageHead";
-import { createServerApiClient } from "../../../utils/fetch/client";
+import AdminPageError from "../../../components/Error/AdminPageError";
+import { requireAdminPageAccess } from "../../../utils/auth/admin";
+
+import type { AdminPageGuardProps } from "../../../utils/auth/admin";
+
+type AdminGroupIndexPageProps = AdminPageGuardProps & {
+  groups: any[];
+};
 
 export const getServerSideProps = async ({ req }: { req: NextApiRequest }) => {
-  const client = createServerApiClient(req);
+  const accessResult = await requireAdminPageAccess(req, "/admin/group");
+  if (!accessResult.ok) {
+    return accessResult.result;
+  }
+
+  const { client } = accessResult;
 
   try {
     const groupsRes = await client.GET("/group", {
@@ -32,19 +44,26 @@ export const getServerSideProps = async ({ req }: { req: NextApiRequest }) => {
     });
 
     if (!groupsRes.data || !groupsRes.data.groups) {
-      return { props: { groups: [] } };
+      return { props: { adminPageError: null, groups: [] } };
     }
 
-    return { props: { groups: groupsRes.data.groups } };
+    return { props: { adminPageError: null, groups: groupsRes.data.groups } };
   } catch (error) {
     console.error("Failed to fetch groups:", error);
-    return { props: { groups: [] } };
+    return { props: { adminPageError: null, groups: [] } };
   }
 };
 
-const AdminGroupIndexPage = ({
-  groups,
-}: InferGetServerSidePropsType<typeof getServerSideProps>) => {
+const AdminGroupIndexPage = ({ groups, adminPageError }: AdminGroupIndexPageProps) => {
+  if (adminPageError) {
+    return (
+      <>
+        <PageHead title="[管理者用] エラー" />
+        <AdminPageError title={adminPageError.title} message={adminPageError.message} />
+      </>
+    );
+  }
+
   return (
     <>
       <PageHead title="[管理者用] グループ一覧" />
@@ -79,7 +98,7 @@ const AdminGroupIndexPage = ({
                   </TableRow>
                 </TableHead>
                 <TableBody>
-                  {groups.map((group) => (
+                  {groups.map((group: any) => (
                     <TableRow key={group.groupId}>
                       <TableCell>
                         <Link href={`/admin/group/${group.groupId}`}>{group.name}</Link>

--- a/pages/admin/group/index.tsx
+++ b/pages/admin/group/index.tsx
@@ -21,9 +21,12 @@ import AdminPageError from "../../../components/Error/AdminPageError";
 import { requireAdminPageAccess } from "../../../utils/auth/admin";
 
 import type { AdminPageGuardProps } from "../../../utils/auth/admin";
+import type { components } from "../../../utils/fetch/api.d.ts";
+
+type GroupListItem = components["schemas"]["ResGetGroupObjectGroup"];
 
 type AdminGroupIndexPageProps = AdminPageGuardProps & {
-  groups: any[];
+  groups: GroupListItem[];
 };
 
 export const getServerSideProps = async ({ req }: { req: NextApiRequest }) => {
@@ -98,7 +101,7 @@ const AdminGroupIndexPage = ({ groups, adminPageError }: AdminGroupIndexPageProp
                   </TableRow>
                 </TableHead>
                 <TableBody>
-                  {groups.map((group: any) => (
+                  {groups.map((group) => (
                     <TableRow key={group.groupId}>
                       <TableCell>
                         <Link href={`/admin/group/${group.groupId}`}>{group.name}</Link>

--- a/pages/admin/group/new.tsx
+++ b/pages/admin/group/new.tsx
@@ -1,3 +1,4 @@
+import type { InferGetServerSidePropsType, NextApiRequest } from "next";
 import { useRouter } from "next/router";
 import { useState } from "react";
 
@@ -16,11 +17,28 @@ import { ButtonLink } from "@/components/Common/ButtonLink";
 import Heading from "@/components/Common/Heading";
 import PageHead from "@/components/Common/PageHead";
 import { useErrorState } from "@/components/contexts/ErrorStateContext";
+import AdminPageError from "@/components/Error/AdminPageError";
 import { useAuthState } from "@/hook/useAuthState";
+import { requireAdminPageAccess } from "@/utils/auth/admin";
 import { GRANT_INFRA } from "@/utils/auth/grants";
 import { apiClient } from "@/utils/fetch/client";
 
-const AdminGroupNewPage = () => {
+export const getServerSideProps = async ({ req }: { req: NextApiRequest }) => {
+  const accessResult = await requireAdminPageAccess(req, "/admin/group/new");
+  if (!accessResult.ok) {
+    return accessResult.result;
+  }
+
+  return {
+    props: {
+      adminPageError: null,
+    },
+  };
+};
+
+const AdminGroupNewPage = ({
+  adminPageError,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) => {
   const router = useRouter();
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
@@ -30,6 +48,15 @@ const AdminGroupNewPage = () => {
   const { setNewError } = useErrorState();
   const { authState } = useAuthState();
   const canAccessGroupAdmin = authState.grants.includes(GRANT_INFRA);
+
+  if (adminPageError) {
+    return (
+      <>
+        <PageHead title="[管理者用] エラー" />
+        <AdminPageError title={adminPageError.title} message={adminPageError.message} />
+      </>
+    );
+  }
 
   const handleSubmit = async () => {
     if (!name.trim() || !description.trim()) {

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -1,3 +1,5 @@
+import type { InferGetServerSidePropsType, NextApiRequest } from "next";
+
 import {
   BuildCircle,
   CurrencyYen,
@@ -11,10 +13,25 @@ import { Box, Grid, Stack, Typography } from "@mui/material";
 
 import AdminMenuCard from "@/components/Admin/AdminMenuCard";
 import PageHead from "@/components/Common/PageHead";
+import AdminPageError from "@/components/Error/AdminPageError";
 import { useAuthState } from "@/hook/useAuthState";
+import { requireAdminPageAccess } from "@/utils/auth/admin";
 import { GRANT_ACCOUNT, GRANT_INFRA } from "@/utils/auth/grants";
 
-const AdminPage = () => {
+export const getServerSideProps = async ({ req }: { req: NextApiRequest }) => {
+  const accessResult = await requireAdminPageAccess(req, "/admin");
+  if (!accessResult.ok) {
+    return accessResult.result;
+  }
+
+  return {
+    props: {
+      adminPageError: null,
+    },
+  };
+};
+
+const AdminPage = ({ adminPageError }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
   const { authState } = useAuthState();
   const canAccessBudgetAdmin = authState.grants.includes(GRANT_ACCOUNT);
   const canAccessForceCheckoutAdmin = authState.grants.includes(GRANT_INFRA);
@@ -31,6 +48,15 @@ const AdminPage = () => {
     canAccessGradeUpdateAdmin ||
     canAccessReentryAdmin ||
     canAccessInfraAdmin;
+
+  if (adminPageError) {
+    return (
+      <>
+        <PageHead title="[管理者用] エラー" />
+        <AdminPageError title={adminPageError.title} message={adminPageError.message} />
+      </>
+    );
+  }
 
   return (
     <>

--- a/pages/admin/infra/index.tsx
+++ b/pages/admin/infra/index.tsx
@@ -1,3 +1,4 @@
+import type { InferGetServerSidePropsType, NextApiRequest } from "next";
 import { useState } from "react";
 
 import { ArrowBack, Autorenew, PersonOff, School } from "@mui/icons-material";
@@ -21,7 +22,9 @@ import { ButtonLink } from "@/components/Common/ButtonLink";
 import Heading from "@/components/Common/Heading";
 import PageHead from "@/components/Common/PageHead";
 import { useErrorState } from "@/components/contexts/ErrorStateContext";
+import AdminPageError from "@/components/Error/AdminPageError";
 import { useAuthState } from "@/hook/useAuthState";
+import { requireAdminPageAccess } from "@/utils/auth/admin";
 import { apiClient } from "@/utils/fetch/client";
 
 type InfraAction = "inactive" | "school-grade";
@@ -57,12 +60,36 @@ const ACTION_CONTENT: Record<
   },
 };
 
-const AdminInfraPage = () => {
+export const getServerSideProps = async ({ req }: { req: NextApiRequest }) => {
+  const accessResult = await requireAdminPageAccess(req, "/admin/infra");
+  if (!accessResult.ok) {
+    return accessResult.result;
+  }
+
+  return {
+    props: {
+      adminPageError: null,
+    },
+  };
+};
+
+const AdminInfraPage = ({
+  adminPageError,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) => {
   const { authState } = useAuthState();
   const { removeError, setNewError } = useErrorState();
   const [pendingAction, setPendingAction] = useState<InfraAction | null>(null);
   const [runningAction, setRunningAction] = useState<InfraAction | null>(null);
   const [result, setResult] = useState<ActionResult>(null);
+
+  if (adminPageError) {
+    return (
+      <>
+        <PageHead title="[管理者用] エラー" />
+        <AdminPageError title={adminPageError.title} message={adminPageError.message} />
+      </>
+    );
+  }
 
   const handleCloseDialog = () => {
     if (runningAction !== null) return;

--- a/pages/admin/payment/index.tsx
+++ b/pages/admin/payment/index.tsx
@@ -1,4 +1,4 @@
-import type { InferGetServerSidePropsType, NextApiRequest } from "next";
+import type { NextApiRequest } from "next";
 import { useState } from "react";
 
 import { ArrowBack } from "@mui/icons-material";
@@ -17,29 +17,50 @@ import {
 
 import { ButtonLink } from "../../../components/Common/ButtonLink";
 import PageHead from "../../../components/Common/PageHead";
+import AdminPageError from "../../../components/Error/AdminPageError";
 import PaymentDetailDialog from "../../../components/Payment/PaymentDetailDialog";
 import { Payment } from "../../../interfaces/payment";
-import { createServerApiClient } from "../../../utils/fetch/client";
+import { requireAdminPageAccess } from "../../../utils/auth/admin";
+
+import type { AdminPageGuardProps } from "../../../utils/auth/admin";
+
+type AdminPaymentPageProps = AdminPageGuardProps & {
+  payments: Payment[];
+};
 
 export const getServerSideProps = async ({ req }: { req: NextApiRequest }) => {
-  const client = createServerApiClient(req);
+  const accessResult = await requireAdminPageAccess(req, "/admin/payment");
+  if (!accessResult.ok) {
+    return accessResult.result;
+  }
+
+  const { client } = accessResult;
 
   try {
     const paymentsRes = await client.GET("/payment");
 
     if (!paymentsRes.data || !paymentsRes.data.payments) {
-      return { props: { payments: [] } };
+      return { props: { adminPageError: null, payments: [] } };
     }
 
-    return { props: { payments: paymentsRes.data.payments } };
+    return { props: { adminPageError: null, payments: paymentsRes.data.payments } };
   } catch (error) {
     console.error("Failed to fetch payments:", error);
-    return { props: { payments: [] } };
+    return { props: { adminPageError: null, payments: [] } };
   }
 };
 
-const AdminPaymentPage = ({ payments }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
+const AdminPaymentPage = ({ payments, adminPageError }: AdminPaymentPageProps) => {
   const [targetPayment, updateTargetPayment] = useState<Payment | null>(null);
+
+  if (adminPageError) {
+    return (
+      <>
+        <PageHead title="[管理者用] エラー" />
+        <AdminPageError title={adminPageError.title} message={adminPageError.message} />
+      </>
+    );
+  }
 
   return (
     <>
@@ -64,7 +85,7 @@ const AdminPaymentPage = ({ payments }: InferGetServerSidePropsType<typeof getSe
                 </TableRow>
               </TableHead>
               <TableBody>
-                {payments.map((payment) => (
+                {payments.map((payment: Payment) => (
                   <TableRow key={payment.paymentId}>
                     <TableCell>{payment.studentNumber}</TableCell>
                     <TableCell>{payment.transferName}</TableCell>

--- a/pages/admin/payment/index.tsx
+++ b/pages/admin/payment/index.tsx
@@ -15,14 +15,14 @@ import {
   Typography,
 } from "@mui/material";
 
-import { ButtonLink } from "../../../components/Common/ButtonLink";
-import PageHead from "../../../components/Common/PageHead";
-import AdminPageError from "../../../components/Error/AdminPageError";
-import PaymentDetailDialog from "../../../components/Payment/PaymentDetailDialog";
-import { Payment } from "../../../interfaces/payment";
-import { requireAdminPageAccess } from "../../../utils/auth/admin";
+import { ButtonLink } from "@/components/Common/ButtonLink";
+import PageHead from "@/components/Common/PageHead";
+import AdminPageError from "@/components/Error/AdminPageError";
+import PaymentDetailDialog from "@/components/Payment/PaymentDetailDialog";
+import { Payment } from "@/interfaces/payment";
+import { requireAdminPageAccess } from "@/utils/auth/admin";
 
-import type { AdminPageGuardProps } from "../../../utils/auth/admin";
+import type { AdminPageGuardProps } from "@/utils/auth/admin";
 
 type AdminPaymentPageProps = AdminPageGuardProps & {
   payments: Payment[];

--- a/pages/admin/reentry/index.tsx
+++ b/pages/admin/reentry/index.tsx
@@ -1,4 +1,4 @@
-import type { InferGetServerSidePropsType, NextApiRequest } from "next";
+import type { NextApiRequest } from "next";
 import { useRouter } from "next/router";
 import { useMemo, useState } from "react";
 
@@ -25,26 +25,38 @@ import {
 import { ButtonLink } from "@/components/Common/ButtonLink";
 import PageHead from "@/components/Common/PageHead";
 import { useErrorState } from "@/components/contexts/ErrorStateContext";
+import AdminPageError from "@/components/Error/AdminPageError";
 import { useAuthState } from "@/hook/useAuthState";
-import { apiClient, createServerApiClient } from "@/utils/fetch/client";
+import { requireAdminPageAccess } from "@/utils/auth/admin";
+import { apiClient } from "@/utils/fetch/client";
 
+import type { AdminPageGuardProps } from "@/utils/auth/admin";
 import type { components } from "@/utils/fetch/api.d.ts";
 
 type AdminReentry = components["schemas"]["ResGetAdminReentryObjectReentry"];
+type AdminReentryPageProps = AdminPageGuardProps & {
+  reentries: AdminReentry[];
+};
 
 export const getServerSideProps = async ({ req }: { req: NextApiRequest }) => {
-  const client = createServerApiClient(req);
+  const accessResult = await requireAdminPageAccess(req, "/admin/reentry");
+  if (!accessResult.ok) {
+    return accessResult.result;
+  }
+
+  const { client } = accessResult;
 
   try {
     const reentriesRes = await client.GET("/admin/reentry");
     return {
       props: {
+        adminPageError: null,
         reentries: reentriesRes.data?.reentries ?? ([] as AdminReentry[]),
       },
     };
   } catch (error) {
     console.error("Failed to fetch pending reentry requests:", error);
-    return { props: { reentries: [] as AdminReentry[] } };
+    return { props: { adminPageError: null, reentries: [] as AdminReentry[] } };
   }
 };
 
@@ -57,15 +69,22 @@ const getPaymentStatusChip = (
   return { color: "default", label: status };
 };
 
-const AdminReentryPage = ({
-  reentries,
-}: InferGetServerSidePropsType<typeof getServerSideProps>) => {
+const AdminReentryPage = ({ reentries, adminPageError }: AdminReentryPageProps) => {
   const router = useRouter();
   const { authState } = useAuthState();
   const { removeError, setNewError } = useErrorState();
   const [targetReentry, setTargetReentry] = useState<AdminReentry | null>(null);
   const [note, setNote] = useState("");
   const [isLoading, setIsLoading] = useState(false);
+
+  if (adminPageError) {
+    return (
+      <>
+        <PageHead title="[管理者用] エラー" />
+        <AdminPageError title={adminPageError.title} message={adminPageError.message} />
+      </>
+    );
+  }
 
   const dialogOpen = targetReentry !== null;
   const paymentStatus = useMemo(() => {
@@ -156,7 +175,7 @@ const AdminReentryPage = ({
                 </TableRow>
               </TableHead>
               <TableBody>
-                {reentries.map((reentry) => {
+                {reentries.map((reentry: AdminReentry) => {
                   const chip = getPaymentStatusChip(reentry.paymentStatus);
                   return (
                     <TableRow key={reentry.reentryId}>

--- a/utils/auth/admin.ts
+++ b/utils/auth/admin.ts
@@ -1,0 +1,124 @@
+import type { GetServerSidePropsContext, GetServerSidePropsResult, NextApiRequest } from "next";
+
+import { createServerApiClient } from "@/utils/fetch/client";
+
+import { GRANT_ACCOUNT, GRANT_INFRA } from "./grants";
+
+import type { components } from "@/utils/fetch/api.d.ts";
+
+type ServerSideRequest = GetServerSidePropsContext["req"] | NextApiRequest;
+
+export type AdminPageError = {
+  message: string;
+  title: string;
+};
+
+export type AdminPageGuardProps = {
+  adminPageError: AdminPageError | null;
+};
+
+type AdminPageAccessResult =
+  | {
+      client: ReturnType<typeof createServerApiClient>;
+      grants: string[];
+      ok: true;
+    }
+  | {
+      ok: false;
+      result: GetServerSidePropsResult<AdminPageGuardProps>;
+    };
+
+export const getRequiredAdminGrantsByPath = (pathname: string): string[] | null => {
+  if (!pathname.startsWith("/admin")) return null;
+  if (pathname === "/admin") return [GRANT_ACCOUNT, GRANT_INFRA];
+  if (pathname.startsWith("/admin/budget")) return [GRANT_ACCOUNT];
+  if (pathname.startsWith("/admin/group")) return [GRANT_INFRA];
+  if (pathname.startsWith("/admin/payment")) return [GRANT_ACCOUNT];
+  if (pathname.startsWith("/admin/grade-update")) return [GRANT_INFRA];
+  if (pathname.startsWith("/admin/reentry")) return [GRANT_INFRA];
+  if (pathname.startsWith("/admin/activity")) return [GRANT_INFRA];
+  if (pathname.startsWith("/admin/infra")) return [GRANT_INFRA];
+  return [GRANT_ACCOUNT, GRANT_INFRA];
+};
+
+export const normalizeGrants = (grants: string[] | undefined): string[] =>
+  Array.from(new Set((grants ?? []).map((grant) => grant.trim()).filter((grant) => grant !== "")));
+
+export const hasRequiredAdminGrant = (pathname: string, grants: string[]): boolean => {
+  const requiredAdminGrants = getRequiredAdminGrantsByPath(pathname);
+  if (requiredAdminGrants === null) return true;
+  return requiredAdminGrants.some((grant) => grants.includes(grant));
+};
+
+const createAccessDeniedError = (): AdminPageError => ({
+  message: "このページを表示する権限がありません。トップページに戻ってください。",
+  title: "権限がありません",
+});
+
+const createGrantFetchError = (message: string): AdminPageError => ({
+  message,
+  title: "エラーが発生しました",
+});
+
+export const requireAdminPageAccess = async (
+  req: ServerSideRequest,
+  pathname: string,
+): Promise<AdminPageAccessResult> => {
+  const client = createServerApiClient(req);
+
+  try {
+    const grantsRes = await client.GET("/user/me/grants", {});
+
+    if (grantsRes.error) {
+      const status = grantsRes.response.status;
+      if (status === 401 || status === 403) {
+        return {
+          ok: false,
+          result: {
+            redirect: {
+              destination: "/login",
+              permanent: false,
+            },
+          },
+        };
+      }
+
+      console.error(`Failed to fetch grants for ${pathname}:`, grantsRes.error);
+      return {
+        ok: false,
+        result: {
+          props: {
+            adminPageError: createGrantFetchError(`権限情報の取得に失敗しました (HTTP ${status})`),
+          },
+        },
+      };
+    }
+
+    const grants = normalizeGrants(
+      (grantsRes.data as components["schemas"]["ResGetUserMeGrants"] | undefined)?.grants,
+    );
+
+    if (!hasRequiredAdminGrant(pathname, grants)) {
+      return {
+        ok: false,
+        result: {
+          props: {
+            adminPageError: createAccessDeniedError(),
+          },
+        },
+      };
+    }
+
+    return { client, grants, ok: true };
+  } catch (error) {
+    console.error(`Failed to validate admin access for ${pathname}:`, error);
+    return {
+      ok: false,
+      result: {
+        props: {
+          adminPageError: createGrantFetchError("権限情報の取得に失敗しました"),
+        },
+      },
+    };
+  }
+};

--- a/utils/auth/admin.ts
+++ b/utils/auth/admin.ts
@@ -1,8 +1,7 @@
 import type { GetServerSidePropsContext, GetServerSidePropsResult, NextApiRequest } from "next";
 
+import { GRANT_ACCOUNT, GRANT_INFRA } from "@/utils/auth/grants";
 import { createServerApiClient } from "@/utils/fetch/client";
-
-import { GRANT_ACCOUNT, GRANT_INFRA } from "./grants";
 
 import type { components } from "@/utils/fetch/api.d.ts";
 

--- a/utils/fetch/api.d.ts
+++ b/utils/fetch/api.d.ts
@@ -2863,12 +2863,14 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description Get place visit history */
+        /** @description Get place visit history. startAt から endAt までの訪問回数を返す。単日範囲では訪問レコード数、複数日範囲では同一ユーザーの同一日の複数回訪問を1回として数える。 */
         get: {
             parameters: {
                 query: {
-                    period: "day" | "week" | "month";
-                    date: string;
+                    /** @description 集計開始日時。endAt 以下である必要がある。 */
+                    startAt: string;
+                    /** @description 集計終了日時。startAt 以上である必要がある。 */
+                    endAt: string;
                 };
                 header?: never;
                 path: {

--- a/utils/fetch/bundle.gen.yml
+++ b/utils/fetch/bundle.gen.yml
@@ -1962,7 +1962,8 @@ paths:
     get:
       tags:
         - activity
-      description: Get place visit history
+      description: >-
+        Get place visit history. startAt から endAt までの訪問回数を返す。単日範囲では訪問レコード数、複数日範囲では同一ユーザーの同一日の複数回訪問を1回として数える。
       security:
         - BearerAuth: []
       parameters:
@@ -1971,21 +1972,20 @@ paths:
           required: true
           schema:
             type: string
-        - name: period
+        - name: startAt
           in: query
           required: true
           schema:
             type: string
-            enum:
-              - day
-              - week
-              - month
-        - name: date
+            format: date-time
+          description: 集計開始日時。endAt 以下である必要がある。
+        - name: endAt
           in: query
           required: true
           schema:
             type: string
-            format: date
+            format: date-time
+          description: 集計終了日時。startAt 以上である必要がある。
       responses:
         '200':
           description: Success get place history


### PR DESCRIPTION
## 概要
- バックエンド PR 312 の `/activity/place/{place}/history` 変更に追従
- フロント側の履歴取得を `period/date` から `startAt/endAt` に変更
- OpenAPI 定義と生成型を更新

## 変更内容
- `pages/activity/[placeId]/index.tsx` で日別・週別・月別の表示基準日から `startAt/endAt` を組み立てるよう変更
- 週別・月別で入っていた旧API向けのオフセット処理を削除
- `utils/fetch/bundle.gen.yml` をバックエンド仕様に合わせて更新し、`pnpm generate` で `utils/fetch/api.d.ts` を再生成
- `components/Activity/VisitHistorySection.tsx` の古い TODO を削除

## 関連PR
- Backend: https://github.com/SIT-DigiCre/digicore_v3_backend/pull/312

## 確認
- `pnpm generate`
- `pnpm typecheck`
- `pnpm lint`