### PR TITLE
fix: 作品編集後に編集ページにリダイレクトされる問題

### DIFF
--- a/src/pages/work/[id].tsx
+++ b/src/pages/work/[id].tsx
@@ -153,7 +153,7 @@ const WorkDetailPage = ({ id, modeStr, workDetail, workPublic, tags }: WorkDetai
         },
       });
       removeError("work-put-fail");
-      router.reload();
+      router.replace(`/work/${id}`);
     } catch {
       setNewError({ message: "Workの更新に失敗しました", name: "work-put-fail" });
     }


### PR DESCRIPTION
## 概要

- 作品編集完了後のリダイレクト先を修正しました。
-  編集ページへの「保存」クリック後、編集ページがリロードされるのではなく、該当作品の詳細ページ `/work/{id}` へ遷移するように変更しました。