### PR TITLE
enh: ユーザーが重複登録された際の表示を改善

### DIFF
--- a/src/pages/signup/callback.tsx
+++ b/src/pages/signup/callback.tsx
@@ -22,7 +22,7 @@ export const getServerSideProps: GetServerSideProps<Props> = async ({ query, req
   const result = await client.POST("/signup/callback", { body: { code } });
 
   // 重複登録時にはリダイレクトを促すページを表示する
-  if (result.response.status == 409) {
+  if (result.response.status === 409) {
     return { props: { duplicatedSignup: true } };
   }
 

--- a/src/pages/signup/callback.tsx
+++ b/src/pages/signup/callback.tsx
@@ -2,11 +2,13 @@ import type { GetServerSideProps } from "next";
 
 import { Stack, Typography } from "@mui/material";
 
+import { ButtonLink } from "@/components/Common/ButtonLink";
 import Heading from "@/components/Common/Heading";
 import { createServerApiClient } from "@/utils/fetch/client";
 
 type Props = {
   codeMissing?: boolean;
+  duplicatedSignup?: boolean;
   signupFailed?: boolean;
 };
 
@@ -19,6 +21,11 @@ export const getServerSideProps: GetServerSideProps<Props> = async ({ query, req
   const client = createServerApiClient(req);
   const result = await client.POST("/signup/callback", { body: { code } });
 
+  // 重複登録時にはリダイレクトを促すページを表示する
+  if (result.response.status == 409) {
+    return { props: { duplicatedSignup: true } };
+  }
+
   if (result.data?.jwt) {
     const jwt = result.data.jwt;
     const maxAge = 60 * 60 * 24 * 7;
@@ -30,7 +37,19 @@ export const getServerSideProps: GetServerSideProps<Props> = async ({ query, req
   return { props: { signupFailed: true } };
 };
 
-const SignupCallbackPage = ({ codeMissing, signupFailed }: Props) => {
+const SignupCallbackPage = ({ codeMissing, duplicatedSignup, signupFailed }: Props) => {
+  if (duplicatedSignup) {
+    return (
+      <Stack alignItems="center" mt={20} gap={2}>
+        <Heading level={4}>既に登録済みです</Heading>
+        <Typography variant="body1">ログインしてからユーザー情報登録に進んでください。</Typography>
+        <ButtonLink href="/tutorial/welcome" variant="contained">
+          ログインへ
+        </ButtonLink>
+      </Stack>
+    );
+  }
+
   if (codeMissing || signupFailed) {
     return (
       <Stack alignItems="center" mt={20}>

--- a/src/pages/signup/callback.tsx
+++ b/src/pages/signup/callback.tsx
@@ -43,8 +43,9 @@ const SignupCallbackPage = ({ codeMissing, duplicatedSignup, signupFailed }: Pro
       <Stack alignItems="center" mt={20} gap={2}>
         <Heading level={4}>既に登録済みです</Heading>
         <Typography variant="body1">ログインしてからユーザー情報登録に進んでください。</Typography>
+        {/* 未ログイン状態のためログイン画面にリダイレクト */}
         <ButtonLink href="/tutorial/welcome" variant="contained">
-          ログインへ
+          ログインしてチュートリアルへ
         </ButtonLink>
       </Stack>
     );

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -6,6 +6,22 @@ const isPublicPath = (pathname: string): boolean => {
   return pathname.startsWith("/login") || pathname.startsWith("/signup");
 };
 
+const isStorableNextPath = (request: NextRequest, pathname: string): boolean => {
+  if (pathname.startsWith("/.well-known")) {
+    return false;
+  }
+
+  const fetchDest = request.headers.get("sec-fetch-dest");
+  if (fetchDest && fetchDest !== "document") {
+    return false;
+  }
+
+  const isPrefetch =
+    request.headers.get("next-router-prefetch") === "1" ||
+    request.headers.get("purpose") === "prefetch";
+  return !isPrefetch;
+};
+
 const isValidToken = async (token: string): Promise<boolean> => {
   try {
     const client = createServerApiClientWithToken(token);
@@ -30,7 +46,7 @@ export const proxy = async (request: NextRequest) => {
       const maxAge = 60 * 10; // 10分間
       const isProduction = process.env.NODE_ENV === "production";
 
-      if (!existingNext) {
+      if (!existingNext && isStorableNextPath(request, pathname)) {
         response.cookies.set("next", `${pathname}${search}`, {
           httpOnly: true,
           maxAge,

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -11,6 +11,9 @@ const isStorableNextPath = (request: NextRequest, pathname: string): boolean => 
     return false;
   }
 
+  if (request.method !== "GET") {
+    return false;
+  }
   const fetchDest = request.headers.get("sec-fetch-dest");
   if (fetchDest && fetchDest !== "document") {
     return false;


### PR DESCRIPTION
## 概要

- ユーザーが重複登録された際にチュートリアルへの導線を表示する
- `next`Cookieに意図しない値が設定される問題を修正

## スクリーンショット

<img width="1920" height="989" alt="image" src="https://github.com/user-attachments/assets/e53c9644-f930-4598-831d-49640509f0ab" />