### PR TITLE
fix: 再入部申請ができない問題を修正

### DIFF
--- a/src/pages/login/callback.tsx
+++ b/src/pages/login/callback.tsx
@@ -59,19 +59,6 @@ export const getServerSideProps: GetServerSideProps<LoginCallbackPageProps> = as
     ]);
   };
 
-  const redirectToReentry = (statusMessageRaw: string, jwt?: string) => {
-    const statusMessage = encodeURIComponent(statusMessageRaw);
-    if (jwt) {
-      setAuthCookies(jwt);
-    }
-    return {
-      redirect: {
-        destination: `/login/reentry?message=${statusMessage}`,
-        permanent: false,
-      },
-    };
-  };
-
   if (result.data?.jwt) {
     const jwt = result.data.jwt;
     const nextCookieValue = req.cookies?.next;
@@ -88,15 +75,18 @@ export const getServerSideProps: GetServerSideProps<LoginCallbackPageProps> = as
     }
 
     if (shouldRedirectToReentry(meResult.error?.message)) {
-      return redirectToReentry(meResult.error?.message ?? "", jwt);
+      setAuthCookies(jwt);
+      const statusMessage = encodeURIComponent(meResult.error?.message ?? "");
+      return {
+        redirect: {
+          destination: `/login/reentry?message=${statusMessage}`,
+          permanent: false,
+        },
+      };
     }
 
     const errorMessage = meResult.error ? JSON.stringify(meResult.error) : "";
     return { props: { errorMessage, loginFailed: true } };
-  }
-
-  if (shouldRedirectToReentry(result.error?.message)) {
-    return redirectToReentry(result.error?.message ?? "");
   }
 
   const errorMessage = result.error ? JSON.stringify(result.error) : "";

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -54,6 +54,6 @@ export const proxy = async (request: NextRequest) => {
 
 export const config = {
   matcher: [
-    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico|css|js|map|txt|xml|woff|woff2|ttf|eot)$).*)",
+    "/((?!_next/static|_next/image|favicon.ico|\\.well-known/|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico|css|js|map|txt|xml|woff|woff2|ttf|eot)$).*)",
   ],
 };


### PR DESCRIPTION
再入部申請フォームにアクセス時にJWTが保持されるようにした。

- JWTが取得できない状態で再入部申請フォームにリダイレクトされることを防いだ
- 意図しないリクエストでCookieが削除されることを防ぐため、`/.well-known/`をProxyから除外した