### PR TITLE
fix: ProxyのMatcherを修正

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -54,6 +54,6 @@ export const proxy = async (request: NextRequest) => {
 
 export const config = {
   matcher: [
-    "/((?!_next/static|_next/image|favicon.ico|\\.well-known/|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico|css|js|map|txt|xml|woff|woff2|ttf|eot)$).*)",
+    "/((?!_next/|favicon.ico|\\.well-known/|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico|css|js|map|txt|xml|woff|woff2|ttf|eot)$).*)",
   ],
 };


### PR DESCRIPTION
#251 でmatcherを修正したが、本番環境では`_next/data`も除外する必要があるため、`_next`配下を一括で除外するよう修正した。