### PR TITLE
プロフィールへの導線を追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,5 +37,5 @@
     "oxlint": "1.56.0",
     "typescript": "5.9.3"
   },
-  "packageManager": "pnpm@10.33.0"
+  "packageManager": "pnpm@11.0.8"
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,15 +1,48 @@
+import type { InferGetServerSidePropsType, NextApiRequest } from "next";
 import { useState } from "react";
 
-import { CheckCircle, CopyAll, CurrencyYen, MeetingRoom, ReceiptLong } from "@mui/icons-material";
-import { Button, Grid, Stack, Typography } from "@mui/material";
+import {
+  AccountCircle,
+  CheckCircle,
+  CopyAll,
+  CurrencyYen,
+  MeetingRoom,
+  ReceiptLong,
+  School as SchoolIcon,
+} from "@mui/icons-material";
+import { Avatar, Box, Button, Card, Chip, Grid, Stack, Typography } from "@mui/material";
 import Link from "next/link";
 
 import { ButtonLink } from "@/components/Common/ButtonLink";
 import Heading from "@/components/Common/Heading";
 import PageHead from "@/components/Common/PageHead";
 import HomeLinkCard from "@/components/Home/HomeLinkCard";
+import { createServerApiClient } from "@/utils/fetch/client";
 
-const IndexPage = () => {
+type PageProps = InferGetServerSidePropsType<typeof getServerSideProps>;
+
+export const getServerSideProps = async ({ req }: { req: NextApiRequest }) => {
+  const client = createServerApiClient(req);
+
+  try {
+    const profileRes = await client.GET("/user/me");
+    const profile = profileRes.data;
+    return {
+      props: {
+        profile: profile,
+      },
+    };
+  } catch (error) {
+    console.error("ユーザープロフィールの取得に失敗しました:", error);
+    return {
+      props: {
+        profile: null,
+      },
+    };
+  }
+};
+
+const IndexPage = ({ profile }: PageProps) => {
   const [isCopied, setIsCopied] = useState(false);
 
   const handleCopyServerUrl = async () => {
@@ -35,6 +68,72 @@ const IndexPage = () => {
       <PageHead title="ホーム" />
       <Stack spacing={2}>
         <Heading level={2}>ようこそ、デジコア3へ</Heading>
+        {profile && (
+          <Card
+            variant="outlined"
+            sx={{
+              display: "flex",
+              flexDirection: "column",
+              height: "100%",
+              p: 2,
+              width: "100%",
+            }}
+          >
+            <Grid container spacing={4} alignItems="center">
+              <Grid size={{ sm: 4, xs: 12 }}>
+                <Box display="flex" justifyContent="center">
+                  <Avatar
+                    src={profile.iconUrl}
+                    alt={`${profile.username}のアイコン`}
+                    sx={{
+                      border: 3,
+                      borderColor: "primary.main",
+                      height: { sm: 150, xs: 120 },
+                      width: { sm: 150, xs: 120 },
+                    }}
+                  />
+                </Box>
+              </Grid>
+
+              <Grid size={{ sm: 6, xs: 12 }}>
+                <Box textAlign={{ sm: "left", xs: "center" }}>
+                  <Heading level={2}>{profile.username}</Heading>
+
+                  {profile.shortIntroduction && (
+                    <Typography variant="h6" color="text.secondary" sx={{ mb: 2 }}>
+                      {profile.shortIntroduction}
+                    </Typography>
+                  )}
+
+                  <Box display="flex" justifyContent={{ sm: "flex-start", xs: "center" }}>
+                    <Chip
+                      icon={<SchoolIcon />}
+                      label={`${profile.schoolGrade}年生`}
+                      color="primary"
+                      variant="outlined"
+                      size="medium"
+                      sx={{
+                        fontSize: "1rem",
+                        fontWeight: "medium",
+                        px: 1,
+                      }}
+                    />
+                  </Box>
+                </Box>
+              </Grid>
+            </Grid>
+
+            <Stack sx={{ alignItems: "flex-end", mt: 2 }}>
+              <ButtonLink
+                href={`/member/${profile.userId}`}
+                variant="contained"
+                startIcon={<AccountCircle />}
+              >
+                プロフィールを見る
+              </ButtonLink>
+            </Stack>
+          </Card>
+        )}
         <Grid container spacing={2} sx={{ alignItems: "stretch" }}>
           <Grid size={{ md: 6, xs: 12 }} sx={{ alignItems: "stretch", display: "flex" }}>
             <HomeLinkCard
@@ -81,6 +180,21 @@ const IndexPage = () => {
             >
               <Typography>
                 部室への入退室を記録できます。今誰が部室にいるのかも確認することができます。
+              </Typography>
+            </HomeLinkCard>
+          </Grid>
+
+          <Grid size={{ md: 6, xs: 12 }} sx={{ alignItems: "stretch", display: "flex" }}>
+            <HomeLinkCard
+              title="プロフィール"
+              action={
+                <ButtonLink href="/user/profile" variant="contained" startIcon={<AccountCircle />}>
+                  プロフィールを編集する
+                </ButtonLink>
+              }
+            >
+              <Typography>
+                公開プロフィールや自己紹介、連絡先などの情報を確認・編集できます。
               </Typography>
             </HomeLinkCard>
           </Grid>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -26,10 +26,19 @@ export const getServerSideProps = async ({ req }: { req: NextApiRequest }) => {
 
   try {
     const profileRes = await client.GET("/user/me");
-    const profile = profileRes.data;
+
+    if (profileRes.error || profileRes.data === undefined) {
+      console.error("ユーザープロフィールの取得に失敗しました:", profileRes.error);
+      return {
+        props: {
+          profile: null,
+        },
+      };
+    }
+
     return {
       props: {
-        profile: profile,
+        profile: profileRes.data,
       },
     };
   } catch (error) {

--- a/src/pages/member/[id].tsx
+++ b/src/pages/member/[id].tsx
@@ -120,6 +120,17 @@ const UserProfilePage = ({ profile, introduction, seed, page, works }: PageProps
   const { authState } = useAuthState();
   const backUrl = seed != null && seed !== "" && `/member/?seed=${seed}&page=${page ?? "1"}`;
 
+  const handleBackClick = () => {
+    const canGoBack =
+      window.history.length > 1 &&
+      (!document.referrer || document.referrer.startsWith(window.location.origin));
+    if (canGoBack) {
+      router.back();
+    } else {
+      router.push("/member/");
+    }
+  };
+
   return (
     <>
       <PageHead title={profile.username} />
@@ -130,20 +141,7 @@ const UserProfilePage = ({ profile, introduction, seed, page, works }: PageProps
             部員一覧に戻る
           </ButtonLink>
         ) : (
-          <Button
-            startIcon={<ArrowBack />}
-            variant="text"
-            onClick={() => {
-              const canGoBack =
-                window.history.length > 1 &&
-                (!document.referrer || document.referrer.startsWith(window.location.origin));
-              if (canGoBack) {
-                router.back();
-              } else {
-                void router.push("/member/");
-              }
-            }}
-          >
+          <Button startIcon={<ArrowBack />} variant="text" onClick={handleBackClick}>
             戻る
           </Button>
         )}

--- a/src/pages/member/[id].tsx
+++ b/src/pages/member/[id].tsx
@@ -130,7 +130,18 @@ const UserProfilePage = ({ profile, introduction, seed, page, works }: PageProps
             部員一覧に戻る
           </ButtonLink>
         ) : (
-          <Button startIcon={<ArrowBack />} variant="text" onClick={() => router.back()}>
+          <Button
+            startIcon={<ArrowBack />}
+            variant="text"
+            onClick={() => {
+              const hasInternalReferrer = document.referrer.startsWith(window.location.origin);
+              if (hasInternalReferrer) {
+                router.back();
+                return;
+              }
+              void router.push("/member/");
+            }}
+          >
             戻る
           </Button>
         )}

--- a/src/pages/member/[id].tsx
+++ b/src/pages/member/[id].tsx
@@ -134,12 +134,12 @@ const UserProfilePage = ({ profile, introduction, seed, page, works }: PageProps
             startIcon={<ArrowBack />}
             variant="text"
             onClick={() => {
-              const hasInternalReferrer = document.referrer.startsWith(window.location.origin);
-              if (hasInternalReferrer) {
+              const isInternalReferrer = document.referrer.startsWith(window.location.origin);
+              if (isInternalReferrer) {
                 router.back();
-                return;
+              } else {
+                void router.push("/member/");
               }
-              void router.push("/member/");
             }}
           >
             戻る

--- a/src/pages/member/[id].tsx
+++ b/src/pages/member/[id].tsx
@@ -1,15 +1,28 @@
 import type { InferGetServerSidePropsType, NextApiRequest } from "next";
 
-import { ArrowBack, School as SchoolIcon } from "@mui/icons-material";
-import { Avatar, Box, Chip, Container, Grid, Paper, Stack, Typography } from "@mui/material";
+import { ArrowBack, Edit, School as SchoolIcon } from "@mui/icons-material";
+import {
+  Avatar,
+  Box,
+  Button,
+  Chip,
+  Container,
+  Grid,
+  Paper,
+  Stack,
+  Typography,
+} from "@mui/material";
+import { useRouter } from "next/router";
 
-import { ButtonLink } from "../../components/Common/ButtonLink";
-import Heading from "../../components/Common/Heading";
-import PageHead from "../../components/Common/PageHead";
-import MarkdownView from "../../components/Markdown/MarkdownView";
-import { WorkCard } from "../../components/Work/WorkCard";
-import { WorkDetail } from "../../interfaces/work";
-import { createServerApiClient } from "../../utils/fetch/client";
+import { ButtonLink } from "@/components/Common/ButtonLink";
+import Heading from "@/components/Common/Heading";
+import { IconButtonLink } from "@/components/Common/IconButtonLink";
+import PageHead from "@/components/Common/PageHead";
+import MarkdownView from "@/components/Markdown/MarkdownView";
+import { WorkCard } from "@/components/Work/WorkCard";
+import { useAuthState } from "@/hook/useAuthState";
+import { WorkDetail } from "@/interfaces/work";
+import { createServerApiClient } from "@/utils/fetch/client";
 
 type PageProps = InferGetServerSidePropsType<typeof getServerSideProps>;
 
@@ -103,18 +116,37 @@ export const getServerSideProps = async ({
 };
 
 const UserProfilePage = ({ profile, introduction, seed, page, works }: PageProps) => {
-  const backUrl =
-    seed != null && seed !== "" ? `/member/?seed=${seed}&page=${page ?? "1"}` : "/member/";
+  const router = useRouter();
+  const { authState } = useAuthState();
+  const backUrl = seed != null && seed !== "" && `/member/?seed=${seed}&page=${page ?? "1"}`;
 
   return (
     <>
       <PageHead title={profile.username} />
-      <Container maxWidth="md" sx={{ py: 4 }}>
-        <Stack spacing={2}>
+
+      <Stack direction="row" spacing={2} justifyContent="space-between" alignItems="center">
+        {backUrl ? (
           <ButtonLink href={backUrl} startIcon={<ArrowBack />} variant="text">
             部員一覧に戻る
           </ButtonLink>
+        ) : (
+          <Button startIcon={<ArrowBack />} variant="text" onClick={() => router.back()}>
+            戻る
+          </Button>
+        )}
+        <Stack direction="row" spacing={1}>
+          {authState.isLogined &&
+            authState.user?.userId &&
+            authState.user.userId === profile.userId && (
+              <IconButtonLink href="/user/profile" ariaLabel="プロフィール編集">
+                <Edit />
+              </IconButtonLink>
+            )}
+        </Stack>
+      </Stack>
 
+      <Container sx={{ py: 4 }}>
+        <Stack spacing={2}>
           <Box sx={{ mb: 4 }}>
             <Grid container spacing={4} alignItems="center">
               <Grid size={{ sm: 4, xs: 12 }}>

--- a/src/pages/member/[id].tsx
+++ b/src/pages/member/[id].tsx
@@ -134,8 +134,10 @@ const UserProfilePage = ({ profile, introduction, seed, page, works }: PageProps
             startIcon={<ArrowBack />}
             variant="text"
             onClick={() => {
-              const isInternalReferrer = document.referrer.startsWith(window.location.origin);
-              if (isInternalReferrer) {
+              const canGoBack =
+                window.history.length > 1 &&
+                (!document.referrer || document.referrer.startsWith(window.location.origin));
+              if (canGoBack) {
                 router.back();
               } else {
                 void router.push("/member/");


### PR DESCRIPTION
## 概要

- トップページ(`/`)
  - ユーザープロフィールを追加
- プロフィールページ('/member/[id]`)
  - 「戻る」ボタンの挙動を変更
    - `seed`/`page`が指定されている時は部員一覧ページに遷移
    - それ以外の時は前のページに戻る
  - プロフィール編集ページ(`/user/profile`)へのリンクを追加

## スクリーンショット

<img width="1920" height="989" alt="image" src="https://github.com/user-attachments/assets/ced7a6d2-1d27-4def-a120-032c82453a68" />

<img width="1920" height="989" alt="image" src="https://github.com/user-attachments/assets/1519b9ef-7e46-4cc3-ba29-c652c8018f3d" />
