### PR TITLE
enh: 部員一覧の画像をnext/imageで最適化

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -13,6 +13,11 @@ const nextConfig: NextConfig = {
           ]
         : [
             {
+              hostname: "s3.ap-northeast-1.wasabisys.com",
+              pathname: "/**",
+              protocol: "https",
+            },
+            {
               hostname: "example.com", // デバッグ用
               pathname: "/**",
               protocol: "https",

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,13 +2,22 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   images: {
-    remotePatterns: [
-      {
-        hostname: "s3.ap-northeast-1.wasabisys.com",
-        pathname: "/**",
-        protocol: "https",
-      },
-    ],
+    remotePatterns:
+      process.env.NODE_ENV === "production"
+        ? [
+            {
+              hostname: "s3.ap-northeast-1.wasabisys.com",
+              pathname: "/**",
+              protocol: "https",
+            },
+          ]
+        : [
+            {
+              hostname: "example.com", // デバッグ用
+              pathname: "/**",
+              protocol: "https",
+            },
+          ],
   },
 };
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,0 +1,20 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        hostname: "s3.ap-northeast-1.wasabisys.com",
+        pathname: "/**",
+        protocol: "https",
+      },
+      {
+        hostname: "example.com",
+        pathname: "/**",
+        protocol: "https",
+      },
+    ],
+  },
+};
+
+export default nextConfig;

--- a/next.config.ts
+++ b/next.config.ts
@@ -8,11 +8,6 @@ const nextConfig: NextConfig = {
         pathname: "/**",
         protocol: "https",
       },
-      {
-        hostname: "example.com",
-        pathname: "/**",
-        protocol: "https",
-      },
     ],
   },
 };

--- a/src/pages/member/index.tsx
+++ b/src/pages/member/index.tsx
@@ -11,6 +11,7 @@ import {
   TableRow,
   Typography,
 } from "@mui/material";
+import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/router";
 
@@ -120,7 +121,17 @@ const UserIndexPage = ({
                   {users.map((userProfile) => (
                     <TableRow key={userProfile.userId}>
                       <TableCell>
-                        <Avatar src={userProfile.iconUrl} sx={{ height: 40, width: 40 }} />
+                        <Avatar sx={{ height: 40, width: 40 }}>
+                          {userProfile.iconUrl && (
+                            <Image
+                              src={userProfile.iconUrl}
+                              alt={userProfile.username}
+                              width={40}
+                              height={40}
+                              style={{ objectFit: "cover" }}
+                            />
+                          )}
+                        </Avatar>
                       </TableCell>
                       <TableCell>
                         <Link


### PR DESCRIPTION
## 概要

- [ ] `next.config.ts`にremotePatternsを追加し、外部ストレージからの画像を`next/image`で処理可能にしました。
- [ ] `src/pages/member/index.tsx`のアイコン表示を`img`タグから`next/image`コンポーネントへ置き換えました。ブラウザの通信時に自動でWebp形式へ変換されます。

## スクリーンショット（変更の場合は変更前と変更後が分かるように）

比較項目 | 変更前 (Before) | 変更後 (After)
-- | -- | --
ファイル形式 | <img width="1910" height="935" alt="before" src="https://github.com/user-attachments/assets/85c0b981-5d0d-4a73-9f57-6dadf71031eb" />|<img width="1919" height="929" alt="after" src="https://github.com/user-attachments/assets/47c4f0d3-f81b-49eb-ab37-5dc98f7bc345" />