### PR TITLE
enh: イベント予約枠の説明をMarkdown対応にする

### DIFF
--- a/src/components/Event/EventReservationFrame.tsx
+++ b/src/components/Event/EventReservationFrame.tsx
@@ -26,6 +26,7 @@ import { useAuthState } from "../../hook/useAuthState";
 import { getTimeSpanText } from "../../utils/date-util";
 import { apiClient } from "../../utils/fetch/client";
 import { useErrorState } from "../contexts/ErrorStateContext";
+import MarkdownView from "../Markdown/MarkdownView";
 
 import type { DigicreEventReservation } from "../../interfaces/event";
 
@@ -141,7 +142,7 @@ const EventReservationFrame = ({ eventId, eventReservation }: EventReservationFr
           sx={{ pb: 0 }}
         />
         <CardContent>
-          <Typography>{eventReservation.description}</Typography>
+          <MarkdownView md={eventReservation.description} />
           {eventReservation.users.length > 0 ? (
             <List>
               {eventReservation.users.map((userReservation) => (


### PR DESCRIPTION
<img width="1920" height="989" alt="image" src="https://github.com/user-attachments/assets/67adc343-5b77-4148-a022-1e96bb006e2f" />
