### PR TITLE
enh/電話番号を国際電話に対応する

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@mui/material": "7.3.9",
     "dayjs": "1.11.20",
     "isomorphic-dompurify": "3.5.1",
+    "libphonenumber-js": "^1.13.2",
     "marked": "17.0.4",
     "next": "16.1.7",
     "openapi-fetch": "0.17.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       isomorphic-dompurify:
         specifier: 3.5.1
         version: 3.5.1
+      libphonenumber-js:
+        specifier: ^1.13.2
+        version: 1.13.2
       marked:
         specifier: 17.0.4
         version: 17.0.4
@@ -1061,6 +1064,9 @@ packages:
   lefthook@2.1.4:
     resolution: {integrity: sha512-JNfJ5gAn0KADvJ1I6/xMcx70+/6TL6U9gqGkKvPw5RNMfatC7jIg0Evl97HN846xmfz959BV70l8r3QsBJk30w==}
     hasBin: true
+
+  libphonenumber-js@1.13.2:
+    resolution: {integrity: sha512-S3kmBrptp3yRTm83NUcHy9g1vbwiWMzI8WvY22+koBJ6zkRteLnedBL2VX0MIAGwx2yiyxX4J85pceZyQ6ffgg==}
 
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
@@ -2151,6 +2157,8 @@ snapshots:
       lefthook-openbsd-x64: 2.1.4
       lefthook-windows-arm64: 2.1.4
       lefthook-windows-x64: 2.1.4
+
+  libphonenumber-js@1.13.2: {}
 
   lines-and-columns@1.2.4: {}
 

--- a/src/components/Profile/PhoneInput.tsx
+++ b/src/components/Profile/PhoneInput.tsx
@@ -20,7 +20,7 @@ const PhoneInput = ({ title, onChange, initialPhoneNumber, required }: Props) =>
 
   // 電話番号の判定関数
   const checkIsValid = (value: string) => {
-    const cleaned = value.replace(/[-\s]/g, "");
+    const cleaned = value.replace(/[-\s()]/g, "");
     if (cleaned === "") return true;
 
     if (cleaned.startsWith("+")) {
@@ -49,7 +49,7 @@ const PhoneInput = ({ title, onChange, initialPhoneNumber, required }: Props) =>
           if (!checkIsValid(num)) {
             setError(true);
           } else {
-            const cleanedNum = num.replace(/[-\s]/g, "");
+            const cleanedNum = num.replace(/[-\s()]/g, "");
             setNum(cleanedNum);
             onChange(cleanedNum);
             setError(false);

--- a/src/components/Profile/PhoneInput.tsx
+++ b/src/components/Profile/PhoneInput.tsx
@@ -20,6 +20,9 @@ const PhoneInput = ({ title, onChange, initialPhoneNumber, required }: Props) =>
 
   const checkIsValid = (value: string) => {
     if (value === "") return true;
+    if (value.startsWith("+")) {
+      return isValidPhoneNumber(value);
+    }
     return isValidPhoneNumber(value, "JP");
   };
 

--- a/src/components/Profile/PhoneInput.tsx
+++ b/src/components/Profile/PhoneInput.tsx
@@ -18,8 +18,9 @@ const PhoneInput = ({ title, onChange, initialPhoneNumber, required }: Props) =>
     setNum(initialPhoneNumber ?? "");
   }, [initialPhoneNumber]);
 
+  // 電話番号の判定関数
   const checkIsValid = (value: string) => {
-    const cleaned = value.replace(/[-\s]/g, ""); // ハイフンとスペースを削除
+    const cleaned = value.replace(/[-\s]/g, "");
     if (cleaned === "") return true;
 
     if (cleaned.startsWith("+")) {
@@ -42,14 +43,13 @@ const PhoneInput = ({ title, onChange, initialPhoneNumber, required }: Props) =>
             setError(false);
           }
           setNum(e.target.value);
-          onChange(e.target.value);
         }}
+        // フォーカスが外れたときにバリデーションを行う
         onBlur={() => {
-          // ハイフンを削除し、電話番号であるかをチェック
-          const cleanedNum = num.replace(/[-\s]/g, "");
-          if (!checkIsValid(cleanedNum)) {
+          if (!checkIsValid(num)) {
             setError(true);
           } else {
+            const cleanedNum = num.replace(/[-\s]/g, "");
             setNum(cleanedNum);
             onChange(cleanedNum);
             setError(false);
@@ -59,7 +59,7 @@ const PhoneInput = ({ title, onChange, initialPhoneNumber, required }: Props) =>
         helperText={
           error
             ? "正しい電話番号の形式で入力してください"
-            : "国内番号、または+から始まる国際番号で入力してください"
+            : "国内番号、または+から始まる国際番号を半角で入力してください"
         }
       />
     </Stack>

--- a/src/components/Profile/PhoneInput.tsx
+++ b/src/components/Profile/PhoneInput.tsx
@@ -57,7 +57,7 @@ const PhoneInput = ({ title, onChange, initialPhoneNumber, required }: Props) =>
         helperText={
           error
             ? "正しい電話番号の形式で入力してください"
-            : "日本の番号、または+から始まる国際番号で入力してください"
+            : "国内番号、または+から始まる国際番号で入力してください"
         }
       />
     </Stack>

--- a/src/components/Profile/PhoneInput.tsx
+++ b/src/components/Profile/PhoneInput.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 
 import { Stack, TextField } from "@mui/material";
+import { isValidPhoneNumber } from "libphonenumber-js";
 
 import Heading from "../Common/Heading";
 
@@ -17,6 +18,11 @@ const PhoneInput = ({ title, onChange, initialPhoneNumber, required }: Props) =>
     setNum(initialPhoneNumber ?? "");
   }, [initialPhoneNumber]);
 
+  const checkIsValid = (value: string) => {
+    if (value === "") return true;
+    return isValidPhoneNumber(value, "JP");
+  };
+
   return (
     <Stack spacing={2}>
       <Heading level={4}>{title}</Heading>
@@ -27,7 +33,7 @@ const PhoneInput = ({ title, onChange, initialPhoneNumber, required }: Props) =>
         value={num}
         type="tel"
         onChange={(e) => {
-          if (error && /^\d{10,11}$/.test(e.target.value)) {
+          if (error && checkIsValid(e.target.value)) {
             setError(false);
           }
           setNum(e.target.value);
@@ -35,17 +41,20 @@ const PhoneInput = ({ title, onChange, initialPhoneNumber, required }: Props) =>
         }}
         onBlur={() => {
           // ハイフンを削除し、電話番号であるかをチェック
-          const cleanedNum = num.replace(/-/g, "");
-          if (!/^\d{10,11}$/.test(cleanedNum) && cleanedNum !== "") {
+          const cleanedNum = num.replace(/[-\s]/g, "");
+          if (!checkIsValid(cleanedNum)) {
             setError(true);
           } else {
+            setNum(cleanedNum);
             onChange(cleanedNum);
             setError(false);
           }
         }}
         error={error}
         helperText={
-          error ? "半角数字10桁または11桁で入力してください" : "ハイフン(-)無しで入力してください"
+          error
+            ? "正しい電話番号の形式で入力してください"
+            : "日本の番号、または+から始まる国際番号で入力してください"
         }
       />
     </Stack>

--- a/src/components/Profile/PhoneInput.tsx
+++ b/src/components/Profile/PhoneInput.tsx
@@ -19,11 +19,13 @@ const PhoneInput = ({ title, onChange, initialPhoneNumber, required }: Props) =>
   }, [initialPhoneNumber]);
 
   const checkIsValid = (value: string) => {
-    if (value === "") return true;
-    if (value.startsWith("+")) {
-      return isValidPhoneNumber(value);
+    const cleaned = value.replace(/[-\s]/g, ""); // ハイフンとスペースを削除
+    if (cleaned === "") return true;
+
+    if (cleaned.startsWith("+")) {
+      return isValidPhoneNumber(cleaned);
     }
-    return isValidPhoneNumber(value, "JP");
+    return isValidPhoneNumber(cleaned, "JP");
   };
 
   return (


### PR DESCRIPTION
## 概要

電話番号の入力欄（`PhoneInput.tsx`）において、日本国内の番号だけでなく + から始まる国際電話番号の入力およびバリデーションに対応しました。

## 変更内容

- `libphonenumber-js` を導入して先頭が + で始まる場合は国コード指定なしで判定し、それ以外は従来通り `JP`（日本）として判定する内容を `checkIsValid` に追加
- ユーザーが入力欄からフォーカスを外したタイミングで、バリデーション・ハイフン除去を行うように改善

## スクリーンショット（変更の場合は変更前と変更後が分かるように）

比較項目 | 変更前 (Before) | 変更後 (After)
-- | -- | --
ファイル形式 | <img width="1886" height="922" alt="before" src="https://github.com/user-attachments/assets/f3d20308-b3d7-4ec9-bf18-80103a5c754f" /> | <img width="1919" height="947" alt="after" src="https://github.com/user-attachments/assets/bb2adee1-b9bd-42f6-a422-bcda66a612a6" />