### PR TITLE
fix/ remove-reentry-note-workaround

### DIFF
--- a/src/pages/admin/reentry/index.tsx
+++ b/src/pages/admin/reentry/index.tsx
@@ -114,7 +114,7 @@ const AdminReentryPage = ({ reentries, adminPageError }: AdminReentryPageProps) 
       const response = await apiClient.PUT("/admin/reentry/{reentryId}", {
         body: {
           // TODO: 本来noteは申請者が書き込むものだが、バックエンドの仕様で審査者が書き込むフィールドとして扱われてしまっているため、修正する
-          note: note.trim() === "" ? "xyz" : note.trim(),
+          note: note.trim(),
           status,
         },
         headers: {


### PR DESCRIPTION
## 概要

再入部申請の際に備考を空白にするとxyzの文字列が入力されるバグを修正しました。
