### PR TITLE
feat: 部員一覧に検索機能を追加

### DIFF
--- a/src/components/Member/MemberFilterForm.tsx
+++ b/src/components/Member/MemberFilterForm.tsx
@@ -1,0 +1,22 @@
+import { Box, TextField } from "@mui/material";
+
+type MemberFilterFormProps = {
+  keyword: string;
+  onKeywordChange: (value: string) => void;
+};
+
+export const MemberFilterForm = ({ keyword, onKeywordChange }: MemberFilterFormProps) => {
+  return (
+    <Box sx={{ maxWidth: 400 }}>
+      <TextField
+        label="部員名で絞り込み"
+        placeholder="部員名を入力..."
+        variant="outlined"
+        size="small"
+        fullWidth
+        value={keyword}
+        onChange={(e) => onKeywordChange(e.target.value)}
+      />
+    </Box>
+  );
+};

--- a/src/pages/member/index.tsx
+++ b/src/pages/member/index.tsx
@@ -1,5 +1,5 @@
 import type { InferGetServerSidePropsType, NextApiRequest } from "next";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 
 import {
   Avatar,
@@ -107,15 +107,17 @@ const UserIndexPage = ({
 
   const [keyword, setKeyword] = useState("");
   const { searchResults, searchUsers } = useUserSearch();
+  const searchUsersRef = useRef(searchUsers);
+  searchUsersRef.current = searchUsers;
 
   useEffect(() => {
     if (keyword.length === 0) return;
 
     const timer = setTimeout(() => {
-      searchUsers(keyword);
+      searchUsersRef.current(keyword);
     }, 500);
     return () => clearTimeout(timer);
-  }, [keyword, searchUsers]);
+  }, [keyword]);
 
   const displayUsers = keyword.length >= 1 ? searchResults : users;
 

--- a/src/pages/member/index.tsx
+++ b/src/pages/member/index.tsx
@@ -1,5 +1,5 @@
 import type { InferGetServerSidePropsType, NextApiRequest } from "next";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 
 import {
   Avatar,
@@ -108,6 +108,15 @@ const UserIndexPage = ({
   const [keyword, setKeyword] = useState("");
   const { searchResults, searchUsers } = useUserSearch();
 
+  useEffect(() => {
+    if (keyword.length === 0) return;
+
+    const timer = setTimeout(() => {
+      searchUsers(keyword);
+    }, 500);
+    return () => clearTimeout(timer);
+  }, [keyword, searchUsers]);
+
   const displayUsers = keyword.length >= 1 ? searchResults : users;
 
   return (
@@ -118,7 +127,6 @@ const UserIndexPage = ({
           keyword={keyword}
           onKeywordChange={(value) => {
             setKeyword(value);
-            searchUsers(value);
           }}
         />
         {displayUsers && displayUsers.length > 0 ? (

--- a/src/pages/member/index.tsx
+++ b/src/pages/member/index.tsx
@@ -19,6 +19,7 @@ import { useRouter } from "next/router";
 import PageHead from "../../components/Common/PageHead";
 import Pagination from "../../components/Common/Pagination";
 import { MemberFilterForm } from "../../components/Member/MemberFilterForm";
+import { useUserSearch } from "../../hook/user/useUserSearch";
 import { createServerApiClient } from "../../utils/fetch/client";
 
 const ITEMS_PER_PAGE = 100;
@@ -105,17 +106,21 @@ const UserIndexPage = ({
   const router = useRouter();
 
   const [keyword, setKeyword] = useState("");
-  const displayUsers = users.filter((user) => {
-    if (!keyword) return true;
+  const { searchResults, searchUsers } = useUserSearch();
 
-    const lowerKeyword = keyword.toLowerCase();
-    return user.username.toLowerCase().includes(lowerKeyword);
-  });
+  const displayUsers = keyword.length >= 1 ? searchResults : users;
+
   return (
     <>
       <PageHead title="部員一覧" />
       <Stack spacing={2}>
-        <MemberFilterForm keyword={keyword} onKeywordChange={setKeyword} />
+        <MemberFilterForm
+          keyword={keyword}
+          onKeywordChange={(value) => {
+            setKeyword(value);
+            searchUsers(value);
+          }}
+        />
         {displayUsers && displayUsers.length > 0 ? (
           <>
             <TableContainer>
@@ -156,19 +161,21 @@ const UserIndexPage = ({
                 </TableBody>
               </Table>
             </TableContainer>
-            <Stack alignItems="center">
-              <Pagination
-                page={currentPage}
-                hasPreviousPage={hasPreviousPage}
-                hasNextPage={hasNextPage}
-                onChange={(page) =>
-                  router.push({
-                    pathname: router.pathname,
-                    query: { page, seed },
-                  })
-                }
-              />
-            </Stack>
+            {keyword.length === 0 && (
+              <Stack alignItems="center">
+                <Pagination
+                  page={currentPage}
+                  hasPreviousPage={hasPreviousPage}
+                  hasNextPage={hasNextPage}
+                  onChange={(page) =>
+                    router.push({
+                      pathname: router.pathname,
+                      query: { page, seed },
+                    })
+                  }
+                />
+              </Stack>
+            )}
           </>
         ) : (
           <Typography my={2}>一致する部員がいません</Typography>

--- a/src/pages/member/index.tsx
+++ b/src/pages/member/index.tsx
@@ -1,4 +1,5 @@
 import type { InferGetServerSidePropsType, NextApiRequest } from "next";
+import { useState } from "react";
 
 import {
   Avatar,
@@ -17,6 +18,7 @@ import { useRouter } from "next/router";
 
 import PageHead from "../../components/Common/PageHead";
 import Pagination from "../../components/Common/Pagination";
+import { MemberFilterForm } from "../../components/Member/MemberFilterForm";
 import { createServerApiClient } from "../../utils/fetch/client";
 
 const ITEMS_PER_PAGE = 100;
@@ -102,11 +104,19 @@ const UserIndexPage = ({
 }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
   const router = useRouter();
 
+  const [keyword, setKeyword] = useState("");
+  const displayUsers = users.filter((user) => {
+    if (!keyword) return true;
+
+    const lowerKeyword = keyword.toLowerCase();
+    return user.username.toLowerCase().includes(lowerKeyword);
+  });
   return (
     <>
       <PageHead title="部員一覧" />
       <Stack spacing={2}>
-        {users && users.length > 0 ? (
+        <MemberFilterForm keyword={keyword} onKeywordChange={setKeyword} />
+        {displayUsers && displayUsers.length > 0 ? (
           <>
             <TableContainer>
               <Table sx={{ minWidth: 650 }}>
@@ -118,7 +128,7 @@ const UserIndexPage = ({
                   </TableRow>
                 </TableHead>
                 <TableBody>
-                  {users.map((userProfile) => (
+                  {displayUsers.map((userProfile) => (
                     <TableRow key={userProfile.userId}>
                       <TableCell>
                         <Avatar sx={{ height: 40, width: 40 }}>
@@ -161,7 +171,7 @@ const UserIndexPage = ({
             </Stack>
           </>
         ) : (
-          <Typography my={2}>部員がいません</Typography>
+          <Typography my={2}>一致する部員がいません</Typography>
         )}
       </Stack>
     </>


### PR DESCRIPTION
## 概要

部員一覧画面において、部員名で絞り込める検索機能を追加しました。

## 変更内容

- データベース上の全部員を検索できるように文字入力時に裏で検索API( `useUserSearch` )を呼び出し、テーブルの一覧を即座に切り替えるようにした
- 検索中はページネーションを非表示にし、検索結果を一覧で確認できるようにした
- 検索窓のUIを `src/components/Member/MemberFilterForm.tsx` に新しく作成した。将来的に期での絞り込みにも対応させたい

## スクリーンショット（変更の場合は変更前と変更後が分かるように）

比較項目 | 変更前 (Before) | 変更後 (After)
-- | -- | --
ファイル形式 | <img width="1886" height="922" alt="before" src="https://github.com/user-attachments/assets/094432cb-1f78-47e3-94b4-0bad1b8765d0" /> | <img width="1919" height="947" alt="after" src="https://github.com/user-attachments/assets/5765bcfa-5558-4396-9c40-a9ff484fc3f7" />